### PR TITLE
Upgrade Mockito to 3.x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 
     testImplementation group: 'io.temporal', name: 'temporal-testing', version: '1.0.7'
     testImplementation group: 'junit', name: 'junit', version: '4.13.1'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.9.0'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.10.0'
     testImplementation group: 'org.powermock', name: 'powermock-api-mockito2', version: '2.0.9'
 
     errorproneJavac("com.google.errorprone:javac:9+181-r4173-1")

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 
     testImplementation group: 'io.temporal', name: 'temporal-testing', version: '1.0.5'
     testImplementation group: 'junit', name: 'junit', version: '4.13.1'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.7.7'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.8.0'
     testImplementation group: 'org.powermock', name: 'powermock-api-mockito2', version: '2.0.9'
 
     errorproneJavac("com.google.errorprone:javac:9+181-r4173-1")

--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 
     testImplementation group: 'io.temporal', name: 'temporal-testing', version: '1.0.7'
     testImplementation group: 'junit', name: 'junit', version: '4.13.1'
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.8.0'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.9.0'
     testImplementation group: 'org.powermock', name: 'powermock-api-mockito2', version: '2.0.9'
 
     errorproneJavac("com.google.errorprone:javac:9+181-r4173-1")

--- a/build.gradle
+++ b/build.gradle
@@ -36,8 +36,8 @@ dependencies {
 
     testImplementation group: 'io.temporal', name: 'temporal-testing', version: '1.0.5'
     testImplementation group: 'junit', name: 'junit', version: '4.13.1'
-    testImplementation group: 'org.mockito', name: 'mockito-all', version: '1.10.19'
-    testImplementation group: 'org.powermock', name: 'powermock-api-mockito', version: '1.7.4'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.7.7'
+    testImplementation group: 'org.powermock', name: 'powermock-api-mockito2', version: '2.0.9'
 
     errorproneJavac("com.google.errorprone:javac:9+181-r4173-1")
     errorprone("com.google.errorprone:error_prone_core:2.4.0")

--- a/src/main/java/io/temporal/samples/hello/HelloActivity.java
+++ b/src/main/java/io/temporal/samples/hello/HelloActivity.java
@@ -20,6 +20,7 @@
 package io.temporal.samples.hello;
 
 import io.temporal.activity.ActivityInterface;
+import io.temporal.activity.ActivityMethod;
 import io.temporal.activity.ActivityOptions;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowOptions;
@@ -80,6 +81,7 @@ public class HelloActivity {
   public interface GreetingActivities {
 
     // Define your activity method which can be called during workflow execution
+    @ActivityMethod(name = "greet")
     String composeGreeting(String greeting, String name);
   }
 

--- a/src/main/java/io/temporal/samples/hello/HelloLocalActivity.java
+++ b/src/main/java/io/temporal/samples/hello/HelloLocalActivity.java
@@ -33,27 +33,24 @@ import io.temporal.workflow.WorkflowMethod;
 import java.time.Duration;
 
 /**
- * <p>
- * Hello World Temporal workflow that executes a single local activity. Requires a local instance the
- * Temporal service to be running.
- * </p>
- * <p>
- * Some of the Activities are very short lived and do not need the queuing semantic, flow control, rate limiting
- * and routing capabilities. For these Temporal supports so called local Activity feature. Local Activities are
- * executed in the same worker process as the Workflow that invoked them. Consider using local Activities for functions
- * that are:
- * </p>
- * <ul>
- * <li>no longer than a few seconds</li>
- * <li>do not require global rate limiting</li>
- * <li>do not require routing to specific workers or pools of workers</li>
- * <li>can be implemented in the same binary as the Workflow that invokes them</li>
- *</ul>
+ * Hello World Temporal workflow that executes a single local activity. Requires a local instance
+ * the Temporal service to be running.
  *
- * <p>
- * The main benefit of local Activities is that they are much more efficient in utilizing Temporal service resources
- * and have much lower latency overhead comparing to the usual Activity invocation.
- * </p>
+ * <p>Some of the Activities are very short lived and do not need the queuing semantic, flow
+ * control, rate limiting and routing capabilities. For these Temporal supports so called local
+ * Activity feature. Local Activities are executed in the same worker process as the Workflow that
+ * invoked them. Consider using local Activities for functions that are:
+ *
+ * <ul>
+ *   <li>no longer than a few seconds
+ *   <li>do not require global rate limiting
+ *   <li>do not require routing to specific workers or pools of workers
+ *   <li>can be implemented in the same binary as the Workflow that invokes them
+ * </ul>
+ *
+ * <p>The main benefit of local Activities is that they are much more efficient in utilizing
+ * Temporal service resources and have much lower latency overhead comparing to the usual Activity
+ * invocation.
  */
 public class HelloLocalActivity {
 

--- a/src/test/java/io/temporal/samples/bookingsaga/TripBookingWorkflowTest.java
+++ b/src/test/java/io/temporal/samples/bookingsaga/TripBookingWorkflowTest.java
@@ -22,7 +22,7 @@ package io.temporal.samples.bookingsaga;
 import static io.temporal.samples.bookingsaga.TripBookingSaga.TASK_QUEUE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import io.temporal.client.WorkflowClient;

--- a/src/test/java/io/temporal/samples/fileprocessing/FileProcessingTest.java
+++ b/src/test/java/io/temporal/samples/fileprocessing/FileProcessingTest.java
@@ -20,7 +20,7 @@
 package io.temporal.samples.fileprocessing;
 
 import static io.temporal.samples.fileprocessing.FileProcessingWorker.TASK_QUEUE;
-import static org.mockito.Matchers.anyObject;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
 import io.temporal.api.enums.v1.TimeoutType;
@@ -102,7 +102,7 @@ public class FileProcessingTest {
   @Test
   public void testHappyPath() {
     StoreActivities activities = mock(StoreActivities.class);
-    when(activities.download(anyObject()))
+    when(activities.download(any()))
         .thenReturn(new TaskQueueFileNamePair(HOST_NAME_1, FILE_NAME_UNPROCESSED));
     worker.registerActivitiesImplementations(activities);
 
@@ -128,13 +128,13 @@ public class FileProcessingTest {
 
     verifyNoMoreInteractions(activities, activitiesHost1);
 
-    verifyZeroInteractions(activitiesHost2);
+    verifyNoInteractions(activitiesHost2);
   }
 
   @Test
   public void testHostFailover() {
     StoreActivities activities = mock(StoreActivities.class);
-    when(activities.download(anyObject()))
+    when(activities.download(any()))
         .thenReturn(new TaskQueueFileNamePair(HOST_NAME_1, FILE_NAME_UNPROCESSED))
         .thenReturn(new TaskQueueFileNamePair(HOST_NAME_2, FILE_NAME_UNPROCESSED));
 

--- a/src/test/java/io/temporal/samples/hello/HelloActivityRetryTest.java
+++ b/src/test/java/io/temporal/samples/hello/HelloActivityRetryTest.java
@@ -20,7 +20,7 @@
 package io.temporal.samples.hello;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 import io.temporal.client.WorkflowClient;

--- a/src/test/java/io/temporal/samples/hello/HelloActivityTest.java
+++ b/src/test/java/io/temporal/samples/hello/HelloActivityTest.java
@@ -90,4 +90,12 @@ public class HelloActivityTest {
     String greeting = workflow.getGreeting("World");
     assertEquals("Hello World!", greeting);
   }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testMockedActivityWithoutSettings() {
+    // Mocking activity that has method-level annotations
+    // with no withoutAnnotations() setting results in a failure
+    GreetingActivities activities = mock(GreetingActivities.class);
+    worker.registerActivitiesImplementations(activities);
+  }
 }

--- a/src/test/java/io/temporal/samples/hello/HelloActivityTest.java
+++ b/src/test/java/io/temporal/samples/hello/HelloActivityTest.java
@@ -23,6 +23,7 @@ import static io.temporal.samples.hello.HelloActivity.TASK_QUEUE;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowOptions;
@@ -73,7 +74,10 @@ public class HelloActivityTest {
 
   @Test
   public void testMockedActivity() {
-    GreetingActivities activities = mock(GreetingActivities.class);
+    // withoutAnnotations() is required to stop Mockito from copying
+    // method-level annotations from the GreetingActivities interface
+    GreetingActivities activities =
+        mock(GreetingActivities.class, withSettings().withoutAnnotations());
     when(activities.composeGreeting("Hello", "World")).thenReturn("Hello World!");
     worker.registerActivitiesImplementations(activities);
     testEnv.start();

--- a/src/test/java/io/temporal/samples/hello/HelloAsyncLambdaTest.java
+++ b/src/test/java/io/temporal/samples/hello/HelloAsyncLambdaTest.java
@@ -20,7 +20,7 @@
 package io.temporal.samples.hello;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 import io.temporal.client.WorkflowClient;

--- a/src/test/java/io/temporal/samples/hello/HelloChildTest.java
+++ b/src/test/java/io/temporal/samples/hello/HelloChildTest.java
@@ -21,7 +21,7 @@ package io.temporal.samples.hello;
 
 import static io.temporal.samples.hello.HelloChild.TASK_QUEUE;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import io.temporal.client.WorkflowClient;
@@ -35,7 +35,6 @@ import io.temporal.worker.Worker;
 import java.util.concurrent.atomic.AtomicReference;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -90,7 +89,6 @@ public class HelloChildTest {
   }
 
   @Test
-  @Ignore // TODO: Find out how to deal with cglib based mocks
   public void testMockedChild() {
     worker.registerWorkflowImplementationTypes(GreetingWorkflowImpl.class);
     // As new mock is created on each workflow task the only last one is useful to verify calls.

--- a/src/test/java/io/temporal/samples/hello/HelloCronTest.java
+++ b/src/test/java/io/temporal/samples/hello/HelloCronTest.java
@@ -22,7 +22,7 @@ package io.temporal.samples.hello;
 import static io.temporal.samples.hello.HelloCron.CRON_WORKFLOW_ID;
 import static io.temporal.samples.hello.HelloCron.TASK_QUEUE;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 import io.temporal.api.common.v1.WorkflowExecution;

--- a/src/test/java/io/temporal/samples/hello/HelloExceptionTest.java
+++ b/src/test/java/io/temporal/samples/hello/HelloExceptionTest.java
@@ -22,7 +22,7 @@ package io.temporal.samples.hello;
 import static io.temporal.samples.hello.HelloException.TASK_QUEUE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.when;
 
@@ -42,7 +42,6 @@ import io.temporal.testing.TestWorkflowEnvironment;
 import io.temporal.worker.Worker;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestWatcher;
@@ -134,7 +133,6 @@ public class HelloExceptionTest {
   }
 
   @Test(timeout = 100000)
-  @Ignore // TODO(maxim): Find workaround for mockito breaking reflection
   public void testChildWorkflowTimeout() {
     worker.registerWorkflowImplementationTypes(GreetingWorkflowImpl.class);
     // Mock a child that times out.

--- a/src/test/java/io/temporal/samples/hello/HelloLocalActivityTest.java
+++ b/src/test/java/io/temporal/samples/hello/HelloLocalActivityTest.java
@@ -23,6 +23,7 @@ import static io.temporal.samples.hello.HelloLocalActivity.TASK_QUEUE;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowOptions;
@@ -73,7 +74,10 @@ public class HelloLocalActivityTest {
 
   @Test
   public void testMockedActivity() {
-    GreetingActivities activities = mock(GreetingActivities.class);
+    // withoutAnnotations() is required to stop Mockito from copying
+    // method-level annotations from the GreetingActivities interface
+    GreetingActivities activities =
+        mock(GreetingActivities.class, withSettings().withoutAnnotations());
     when(activities.composeGreeting("Hello", "World")).thenReturn("Hello World!");
     worker.registerActivitiesImplementations(activities);
     testEnv.start();

--- a/src/test/java/io/temporal/samples/hello/HelloPeriodicTest.java
+++ b/src/test/java/io/temporal/samples/hello/HelloPeriodicTest.java
@@ -23,7 +23,7 @@ import static io.temporal.samples.hello.HelloPeriodic.PERIODIC_WORKFLOW_ID;
 import static io.temporal.samples.hello.HelloPeriodic.TASK_QUEUE;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
 import io.temporal.api.common.v1.WorkflowExecution;

--- a/src/test/java/io/temporal/samples/moneybatch/TransferWorkflowTest.java
+++ b/src/test/java/io/temporal/samples/moneybatch/TransferWorkflowTest.java
@@ -20,8 +20,8 @@
 package io.temporal.samples.moneybatch;
 
 import static io.temporal.samples.moneybatch.AccountActivityWorker.TASK_QUEUE;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 

--- a/src/test/java/io/temporal/samples/moneytransfer/TransferWorkflowTest.java
+++ b/src/test/java/io/temporal/samples/moneytransfer/TransferWorkflowTest.java
@@ -20,7 +20,7 @@
 package io.temporal.samples.moneytransfer;
 
 import static io.temporal.samples.moneytransfer.AccountActivityWorker.TASK_QUEUE;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 


### PR DESCRIPTION
## Overview & motivation

Update test code to Mockito 3 and adapt when needed. This PR is inspired by https://github.com/temporalio/sdk-java/issues/332 and should provide an example of how a recent Mockito can be used with Temporal SDK.

## Details

* Upgrade Mockito and PowerMock to the latest versions
* Fix deprecation warnings
* Use `withSettings().withoutAnnotations()` in `HelloActivityTest` to prevent Mockito from copying annotations from activity interface to mock class
* Re-enable `HelloChildTest.testMockedChild()` and `HelloExceptionTest.testChildWorkflowTimeout()` as they no longer fail with Mockito 3, presumably due to Mockito's switch to ByteBuddy
