### PR TITLE
Gradle & Dependencies Update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,10 @@
 // Run 'gradle checkUpdates' to find out which dependencies have newer versions
 
 plugins {
-    id 'net.minecrell.licenser' version '0.4.1'
+    id 'org.cadixdev.licenser' version '0.5.1'
     id 'com.github.sherter.google-java-format' version '0.9'
-    id "net.ltgt.errorprone" version "1.3.0"
-    id 'name.remal.check-updates' version '1.1.4'
+    id "net.ltgt.errorprone" version "2.0.1"
+    id 'name.remal.check-updates' version '1.3.1'
 }
 
 apply plugin: 'java'
@@ -31,16 +31,16 @@ repositories {
 
 dependencies {
     implementation group: 'io.temporal', name: 'temporal-sdk', version: '1.0.7'
-    implementation group: 'commons-configuration', name: 'commons-configuration', version: '1.10'
+    implementation group: 'commons-configuration', name: 'commons-configuration', version: '20041012.002804'
     implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
 
     testImplementation group: 'io.temporal', name: 'temporal-testing', version: '1.0.7'
-    testImplementation group: 'junit', name: 'junit', version: '4.13.1'
+    testImplementation group: 'junit', name: 'junit', version: '4.13.2'
     testImplementation group: 'org.mockito', name: 'mockito-all', version: '1.10.19'
     testImplementation group: 'org.powermock', name: 'powermock-api-mockito', version: '1.7.4'
 
     errorproneJavac("com.google.errorprone:javac:9+181-r4173-1")
-    errorprone("com.google.errorprone:error_prone_core:2.4.0")
+    errorprone("com.google.errorprone:error_prone_core:2.6.0")
 }
 
 compileJava {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
> Task :checkDependencyUpdates
New dependency version: com.google.errorprone:error_prone_core: 2.4.0 -> 2.6.0
New dependency version: commons-configuration:commons-configuration: 1.10 -> 20041012.002804
New dependency version: junit:junit: 4.13.1 -> 4.13.2
New dependency version: name.remal.check-updates:name.remal.check-updates.gradle.plugin: 1.1.4 -> 1.3.1
New dependency version: net.ltgt.errorprone:net.ltgt.errorprone.gradle.plugin: 1.3.0 -> 2.0.1

> Task :checkGradleUpdates
New Gradle version is available: 7.0 (downloadUrl: https://services.gradle.org/distributions/gradle-7.0-bin.zip)