### PR TITLE
Fix for Readme link to Java docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This repository contains sample Workflow applications that demonstrate various c
 
 - Temporal Server repo: https://github.com/temporalio/temporal
 - Temporal Java SDK repo: https://github.com/temporalio/sdk-java
-- Java SDK docs: https://docs.temporal.io/docs/go/introduction
+- Java SDK docs: https://docs.temporal.io/docs/java/introduction/
 
 ## Table of Contents
 


### PR DESCRIPTION
Signed-off-by: Tihomir Surdilovic <tihomir@temporal.io>

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
This PR fixes the link to Java docs in main readme
## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes issue: 

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
