### PR TITLE
Add AsyncChild sample and fix gradle build to run both JUnit4 and JUn…

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,8 @@ All tests are available under [src/test/java](https://github.com/temporalio/samp
 
 - [**Payload Converter**](https://github.com/temporalio/samples-java/tree/master/src/main/java/io/temporal/samples/payloadconverter): Demonstrates the use of a custom payload converter.
 
+- [**Async Child Workflow**](https://github.com/temporalio/samples-java/tree/master/src/main/java/io/temporal/samples/asyncchild): Demonstrates how to invoke a child workflow async, that can complete after parent workflow is already completed.
+
 <!-- @@@SNIPEND -->
 
 ## IDE Integration

--- a/build.gradle
+++ b/build.gradle
@@ -41,10 +41,15 @@ dependencies {
     testImplementation group: 'io.temporal', name: 'temporal-testing-junit4', version: '1.2.0'
     testImplementation group: 'io.temporal', name: 'temporal-testing-junit5', version: '1.2.0'
     testImplementation group: 'junit', name: 'junit', version: '4.13.2'
-    testImplementation platform(group: 'org.junit', name: 'junit-bom', version: '5.7.2')
-    testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter'
     testImplementation group: 'org.mockito', name: 'mockito-core', version: '3.11.2'
     testImplementation group: 'org.powermock', name: 'powermock-api-mockito2', version: '2.0.9'
+
+
+
+    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.0-M1'
+    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.0-M1'
+    testCompileOnly 'junit:junit:4.13.2'
+    testRuntimeOnly 'org.junit.vintage:junit-vintage-engine:5.8.0-M1'
 
     errorproneJavac("com.google.errorprone:javac:9+181-r4173-1")
     errorprone("com.google.errorprone:error_prone_core:2.8.1")

--- a/src/main/java/io/temporal/samples/asyncchild/ChildWorkflow.java
+++ b/src/main/java/io/temporal/samples/asyncchild/ChildWorkflow.java
@@ -1,0 +1,29 @@
+/*
+ *  Copyright (c) 2020 Temporal Technologies, Inc. All Rights Reserved
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.samples.asyncchild;
+
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
+
+@WorkflowInterface
+public interface ChildWorkflow {
+  @WorkflowMethod
+  String executeChild();
+}

--- a/src/main/java/io/temporal/samples/asyncchild/ChildWorkflowImpl.java
+++ b/src/main/java/io/temporal/samples/asyncchild/ChildWorkflowImpl.java
@@ -1,0 +1,31 @@
+/*
+ *  Copyright (c) 2020 Temporal Technologies, Inc. All Rights Reserved
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.samples.asyncchild;
+
+import io.temporal.workflow.Workflow;
+import java.time.Duration;
+
+public class ChildWorkflowImpl implements ChildWorkflow {
+  @Override
+  public String executeChild() {
+    Workflow.sleep(Duration.ofSeconds(3));
+    return "Child workflow done";
+  }
+}

--- a/src/main/java/io/temporal/samples/asyncchild/ParentWorkflow.java
+++ b/src/main/java/io/temporal/samples/asyncchild/ParentWorkflow.java
@@ -1,0 +1,30 @@
+/*
+ *  Copyright (c) 2020 Temporal Technologies, Inc. All Rights Reserved
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.samples.asyncchild;
+
+import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
+
+@WorkflowInterface
+public interface ParentWorkflow {
+  @WorkflowMethod
+  WorkflowExecution executeParent();
+}

--- a/src/main/java/io/temporal/samples/asyncchild/ParentWorkflowImpl.java
+++ b/src/main/java/io/temporal/samples/asyncchild/ParentWorkflowImpl.java
@@ -47,7 +47,5 @@ public class ParentWorkflowImpl implements ParentWorkflow {
     // Call .get on the promise. This will block until the child workflow starts execution (or start
     // fails)
     return childExecution.get();
-
-    // return "Parent workflow completed";
   }
 }

--- a/src/main/java/io/temporal/samples/asyncchild/ParentWorkflowImpl.java
+++ b/src/main/java/io/temporal/samples/asyncchild/ParentWorkflowImpl.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (c) 2020 Temporal Technologies, Inc. All Rights Reserved
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.samples.asyncchild;
+
+import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.api.enums.v1.ParentClosePolicy;
+import io.temporal.workflow.Async;
+import io.temporal.workflow.ChildWorkflowOptions;
+import io.temporal.workflow.Promise;
+import io.temporal.workflow.Workflow;
+
+public class ParentWorkflowImpl implements ParentWorkflow {
+  @Override
+  public WorkflowExecution executeParent() {
+
+    // We set the parentClosePolicy to "Abandon"
+    // This will allow child workflow to continue execution after parent completes
+    ChildWorkflowOptions childWorkflowOptions =
+        ChildWorkflowOptions.newBuilder()
+            .setWorkflowId("childWorkflow")
+            .setParentClosePolicy(ParentClosePolicy.PARENT_CLOSE_POLICY_ABANDON)
+            .build();
+
+    // Get the child workflow stub
+    ChildWorkflow child = Workflow.newChildWorkflowStub(ChildWorkflow.class, childWorkflowOptions);
+    // Start the child workflow async
+    Async.function(child::executeChild);
+    // Get the child workflow execution promise
+    Promise<WorkflowExecution> childExecution = Workflow.getWorkflowExecution(child);
+    // Call .get on the promise. This will block until the child workflow starts execution (or start
+    // fails)
+    return childExecution.get();
+
+    // return "Parent workflow completed";
+  }
+}

--- a/src/main/java/io/temporal/samples/asyncchild/README.md
+++ b/src/main/java/io/temporal/samples/asyncchild/README.md
@@ -1,0 +1,10 @@
+# Async Child Workflow execution
+
+The sample demonstrates shows how to invoke a child workflow
+async.
+The child workflow is allowed to complete its execution
+even after the parent workflow completes. 
+
+```bash
+./gradlew -q execute -PmainClass=io.temporal.samples.asyncchild.Starter
+```

--- a/src/main/java/io/temporal/samples/asyncchild/Starter.java
+++ b/src/main/java/io/temporal/samples/asyncchild/Starter.java
@@ -1,0 +1,95 @@
+/*
+ *  Copyright (c) 2020 Temporal Technologies, Inc. All Rights Reserved
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.samples.asyncchild;
+
+import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.api.workflow.v1.WorkflowExecutionInfo;
+import io.temporal.api.workflowservice.v1.DescribeWorkflowExecutionRequest;
+import io.temporal.api.workflowservice.v1.DescribeWorkflowExecutionResponse;
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.samples.listworkflows.CustomerActivitiesImpl;
+import io.temporal.serviceclient.WorkflowServiceStubs;
+import io.temporal.worker.Worker;
+import io.temporal.worker.WorkerFactory;
+
+public class Starter {
+
+  public static final String TASK_QUEUE = "asyncChildTaskQueue";
+  private static final WorkflowServiceStubs service = WorkflowServiceStubs.newInstance();
+  private static final WorkflowClient client = WorkflowClient.newInstance(service);
+  private static final WorkerFactory factory = WorkerFactory.newInstance(client);
+
+  public static void main(String[] args) {
+    createWorker();
+
+    WorkflowOptions parentWorkflowOptions =
+        WorkflowOptions.newBuilder()
+            .setWorkflowId("parentWorkflow")
+            .setTaskQueue(TASK_QUEUE)
+            .build();
+    ParentWorkflow parentWorkflowStub =
+        client.newWorkflowStub(ParentWorkflow.class, parentWorkflowOptions);
+
+    // Start parent workflow and wait for it to complete
+    WorkflowExecution childWorkflowExecution = parentWorkflowStub.executeParent();
+
+    // Get the child workflow execution status (after parent completed)
+    System.out.println("Child execution status: " + getStatusAsString(childWorkflowExecution));
+
+    // Wait for child workflow to complete
+    sleep(4);
+
+    // Check the status of the child workflow again
+    System.out.println("Child execution status: " + getStatusAsString(childWorkflowExecution));
+
+    System.exit(0);
+  }
+
+  private static void createWorker() {
+    Worker worker = factory.newWorker(TASK_QUEUE);
+    worker.registerWorkflowImplementationTypes(ParentWorkflowImpl.class, ChildWorkflowImpl.class);
+    worker.registerActivitiesImplementations(new CustomerActivitiesImpl());
+
+    factory.start();
+  }
+
+  private static String getStatusAsString(WorkflowExecution execution) {
+    DescribeWorkflowExecutionRequest describeWorkflowExecutionRequest =
+        DescribeWorkflowExecutionRequest.newBuilder()
+            .setNamespace(client.getOptions().getNamespace())
+            .setExecution(execution)
+            .build();
+
+    DescribeWorkflowExecutionResponse resp =
+        service.blockingStub().describeWorkflowExecution(describeWorkflowExecutionRequest);
+
+    WorkflowExecutionInfo workflowExecutionInfo = resp.getWorkflowExecutionInfo();
+    return workflowExecutionInfo.getStatus().toString();
+  }
+
+  private static void sleep(int seconds) {
+    try {
+      Thread.sleep(seconds * 1000);
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+}

--- a/src/test/java/io/temporal/samples/asyncchild/AsyncChildTest.java
+++ b/src/test/java/io/temporal/samples/asyncchild/AsyncChildTest.java
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (c) 2020 Temporal Technologies, Inc. All Rights Reserved
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.samples.asyncchild;
+
+import static org.junit.Assert.assertNotNull;
+
+import io.temporal.api.common.v1.WorkflowExecution;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.testing.TestWorkflowRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+public class AsyncChildTest {
+
+  @Rule
+  public TestWorkflowRule testWorkflowRule =
+      TestWorkflowRule.newBuilder()
+          .setWorkflowTypes(ParentWorkflowImpl.class, ChildWorkflowImpl.class)
+          .build();
+
+  @Test
+  public void testAsyncChildWorkflow() {
+    ParentWorkflow parentWorkflow =
+        testWorkflowRule
+            .getWorkflowClient()
+            .newWorkflowStub(
+                ParentWorkflow.class,
+                WorkflowOptions.newBuilder().setTaskQueue(testWorkflowRule.getTaskQueue()).build());
+
+    WorkflowExecution childExecution = parentWorkflow.executeParent();
+
+    assertNotNull(childExecution);
+  }
+}

--- a/src/test/java/io/temporal/samples/hello/HelloDynamicActivityJUnit5Test.java
+++ b/src/test/java/io/temporal/samples/hello/HelloDynamicActivityJUnit5Test.java
@@ -39,8 +39,8 @@ public class HelloDynamicActivityJUnit5Test {
           .build();
 
   /**
-   * Dynamic activity {@link HelloDynamic.DynamicGreetingActivityImpl} is injected as an implementation for a static
-   * activity interface {@link MyStaticActivity}.
+   * Dynamic activity {@link HelloDynamic.DynamicGreetingActivityImpl} is injected as an
+   * implementation for a static activity interface {@link MyStaticActivity}.
    */
   @Test
   public void testDynamicActivity(MyStaticActivity activity) {


### PR DESCRIPTION
…it5 tests

Signed-off-by: Tihomir Surdilovic <tihomir@temporal.io>

* Adds AsyncChild sample
* Fixes gradle build to run both JUnit4 and JUnit5 tests (currently it was running only the JUnit5 tests after last commit, was a bug introduced)
