### PR TITLE
Remove non-deterministic call in the UpdatableTimer sample.

### DIFF
--- a/src/main/java/io/temporal/samples/updatabletimer/README.md
+++ b/src/main/java/io/temporal/samples/updatabletimer/README.md
@@ -22,23 +22,32 @@ Then in a different terminal window start the Workflow Execution:
 
 Check the output of the Worker window. The expected output is:
 
-```bash
-10:38:56.282 [main] INFO  i.t.s.timerupdate.DynamicSleepWorker - Worker started for task queue: TimerUpdate
-10:39:07.359 [workflow-732875527] INFO  i.t.s.t.DynamicSleepWorkflowImpl - sleepUntil: Thu May 28 10:40:06 PDT 2020
-10:39:07.360 [workflow-732875527] INFO  i.t.s.t.DynamicSleepWorkflowImpl - Going to sleep for PT59.688S
+```
+[...]
+11:39:08.852 [main] INFO  i.t.s.u.DynamicSleepWorkflowWorker - Worker started for task queue: TimerUpdate
+11:39:31.614 [workflow-method] INFO  i.t.s.updatabletimer.UpdatableTimer - sleepUntil: 2021-11-30T19:40:30.979Z
+11:39:31.615 [workflow-method] INFO  i.t.s.updatabletimer.UpdatableTimer - Going to sleep for PT59.727S
 ```
 
 Then run the updater as many times as you want to change timer to 10 seconds from now:
 
 ```bash
 ./gradlew -q execute -PmainClass=io.temporal.samples.updatabletimer.WakeUpTimeUpdater
+```
+ . . .
+```bash
 ./gradlew -q execute -PmainClass=io.temporal.samples.updatabletimer.WakeUpTimeUpdater
 ```
 
 Check the output of the worker window. The expected output is:
 
-```bash
-10:39:12.934 [workflow-732875527] INFO  i.t.s.t.DynamicSleepWorkflowImpl - Going to sleep for PT9.721S
-10:39:20.755 [workflow-732875527] INFO  i.t.s.t.DynamicSleepWorkflowImpl - Going to sleep for PT9.733S
-10:39:30.772 [workflow-732875527] INFO  i.t.s.t.DynamicSleepWorkflowImpl - sleepUntil completed
+```
+11:39:37.740 [signal updateWakeUpTime] INFO  i.t.s.updatabletimer.UpdatableTimer - updateWakeUpTime: 2021-11-30T19:39:47.552Z
+11:39:37.740 [workflow-method] INFO  i.t.s.updatabletimer.UpdatableTimer - Going to sleep for PT9.841S
+```
+ . . .
+```
+11:39:44.679 [signal updateWakeUpTime] INFO  i.t.s.updatabletimer.UpdatableTimer - updateWakeUpTime: 2021-11-30T19:39:54.494Z
+11:39:44.680 [workflow-method] INFO  i.t.s.updatabletimer.UpdatableTimer - Going to sleep for PT9.838S
+11:39:54.565 [workflow-method] INFO  i.t.s.updatabletimer.UpdatableTimer - sleepUntil completed
 ```

--- a/src/main/java/io/temporal/samples/updatabletimer/README.md
+++ b/src/main/java/io/temporal/samples/updatabletimer/README.md
@@ -33,20 +33,15 @@ Then run the updater as many times as you want to change timer to 10 seconds fro
 
 ```bash
 ./gradlew -q execute -PmainClass=io.temporal.samples.updatabletimer.WakeUpTimeUpdater
-```
- . . .
-```bash
 ./gradlew -q execute -PmainClass=io.temporal.samples.updatabletimer.WakeUpTimeUpdater
 ```
 
 Check the output of the worker window. The expected output is:
 
 ```
+[...]
 11:39:37.740 [signal updateWakeUpTime] INFO  i.t.s.updatabletimer.UpdatableTimer - updateWakeUpTime: 2021-11-30T19:39:47.552Z
 11:39:37.740 [workflow-method] INFO  i.t.s.updatabletimer.UpdatableTimer - Going to sleep for PT9.841S
-```
- . . .
-```
 11:39:44.679 [signal updateWakeUpTime] INFO  i.t.s.updatabletimer.UpdatableTimer - updateWakeUpTime: 2021-11-30T19:39:54.494Z
 11:39:44.680 [workflow-method] INFO  i.t.s.updatabletimer.UpdatableTimer - Going to sleep for PT9.838S
 11:39:54.565 [workflow-method] INFO  i.t.s.updatabletimer.UpdatableTimer - sleepUntil completed

--- a/src/main/java/io/temporal/samples/updatabletimer/UpdatableTimer.java
+++ b/src/main/java/io/temporal/samples/updatabletimer/UpdatableTimer.java
@@ -35,8 +35,8 @@ public final class UpdatableTimer {
 
   public void sleepUntil(long wakeUpTime) {
     Instant wakeUpInstant = Instant.ofEpochMilli(wakeUpTime);
-    LocalDateTime date = wakeUpInstant.atZone(ZoneId.systemDefault()).toLocalDateTime();
-    logger.info("sleepUntil: " + date);
+    LocalDateTime date = wakeUpInstant.atZone(ZoneId.of("UTC")).toLocalDateTime();
+    logger.info("sleepUntil: " + date + " UTC");
     this.wakeUpTime = wakeUpTime;
     while (true) {
       wakeUpTimeUpdated = false;
@@ -50,6 +50,9 @@ public final class UpdatableTimer {
   }
 
   public void updateWakeUpTime(long wakeUpTime) {
+    LocalDateTime date =
+        Instant.ofEpochMilli(wakeUpTime).atZone(ZoneId.of("UTC")).toLocalDateTime();
+    logger.info("updateWakeUpTime: " + date + " UTC");
     this.wakeUpTime = wakeUpTime;
     this.wakeUpTimeUpdated = true;
   }

--- a/src/main/java/io/temporal/samples/updatabletimer/UpdatableTimer.java
+++ b/src/main/java/io/temporal/samples/updatabletimer/UpdatableTimer.java
@@ -50,8 +50,7 @@ public final class UpdatableTimer {
   }
 
   public void updateWakeUpTime(long wakeUpTime) {
-    LocalDateTime date =
-        Instant.ofEpochMilli(wakeUpTime).atZone(ZoneId.of("UTC")).toLocalDateTime();
+    LocalDateTime date = Instant.ofEpochMilli(wakeUpTime).atZone(ZoneId.of("UTC")).toLocalDateTime();
     logger.info("updateWakeUpTime: " + date + " UTC");
     this.wakeUpTime = wakeUpTime;
     this.wakeUpTimeUpdated = true;

--- a/src/main/java/io/temporal/samples/updatabletimer/UpdatableTimer.java
+++ b/src/main/java/io/temporal/samples/updatabletimer/UpdatableTimer.java
@@ -22,8 +22,6 @@ package io.temporal.samples.updatabletimer;
 import io.temporal.workflow.Workflow;
 import java.time.Duration;
 import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import org.slf4j.Logger;
 
 public final class UpdatableTimer {
@@ -34,9 +32,7 @@ public final class UpdatableTimer {
   private boolean wakeUpTimeUpdated;
 
   public void sleepUntil(long wakeUpTime) {
-    Instant wakeUpInstant = Instant.ofEpochMilli(wakeUpTime);
-    LocalDateTime date = wakeUpInstant.atZone(ZoneId.of("UTC")).toLocalDateTime();
-    logger.info("sleepUntil: " + date + " UTC");
+    logger.info("sleepUntil: " + Instant.ofEpochMilli(wakeUpTime));
     this.wakeUpTime = wakeUpTime;
     while (true) {
       wakeUpTimeUpdated = false;
@@ -50,8 +46,7 @@ public final class UpdatableTimer {
   }
 
   public void updateWakeUpTime(long wakeUpTime) {
-    LocalDateTime date = Instant.ofEpochMilli(wakeUpTime).atZone(ZoneId.of("UTC")).toLocalDateTime();
-    logger.info("updateWakeUpTime: " + date + " UTC");
+    logger.info("updateWakeUpTime: " + Instant.ofEpochMilli(wakeUpTime));
     this.wakeUpTime = wakeUpTime;
     this.wakeUpTimeUpdated = true;
   }


### PR DESCRIPTION
Small tweak in the _Updatable Timer_ sample to avoid calling a non-deterministic local time zone API form the workflow.