### PR TITLE
Set Fossa to run non-blocking in buildkite

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -15,6 +15,7 @@ steps:
       queue: "default"
       docker: "*"
     command: "fossa init --include-all --no-ansi; fossa analyze --no-ansi -b $${BUILDKITE_BRANCH:-$$(git branch --show-current)}; fossa test --timeout 1800 --no-ansi"
+    branches: "main"
     timeout_in_minutes: 60
     plugins:
       - docker-compose#v3.0.0:


### PR DESCRIPTION
## What was changed
Updated buildkite config to run Fossa non-blocking (only on merge to master)

## Why?
Fossa has too many false positives to run in blocking mode

