### PR TITLE
Add execute task back

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -82,6 +82,11 @@ compileJava {
     dependsOn 'googleJavaFormat'
 }
 
+task execute(type: JavaExec) {
+    main = findProperty("mainClass") ?: ""
+    classpath = sourceSets.main.runtimeClasspath
+}
+
 test {
     useJUnitPlatform()
 }


### PR DESCRIPTION
adds the execute task back to build.gradle (was mistakenly removed during previous cleanup)