### PR TITLE
add missing license header

### DIFF
--- a/src/main/java/io/temporal/samples/payloadconverter/crypto/MyCustomer.java
+++ b/src/main/java/io/temporal/samples/payloadconverter/crypto/MyCustomer.java
@@ -1,3 +1,22 @@
+/*
+ *  Copyright (c) 2020 Temporal Technologies, Inc. All Rights Reserved
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
 package io.temporal.samples.payloadconverter.crypto;
 
 import com.codingrodent.jackson.crypto.Encrypt;


### PR DESCRIPTION
## What was changed
Add license header to Java file

## Why?
The build failed with the following error:
```
> License violations were found: src/main/java/io/temporal/samples/payloadconverter/crypto/MyCustomer.java
```

2. How was this tested:
Re-run build
