### PR TITLE
Fix call to deprecated setActivityPollThreadCount

### DIFF
--- a/src/main/java/io/temporal/samples/hello/HelloCancellationScope.java
+++ b/src/main/java/io/temporal/samples/hello/HelloCancellationScope.java
@@ -264,7 +264,7 @@ public class HelloCancellationScope {
      *
      * In the {@link ActivityOptions} definition the
      * "setMaxConcurrentActivityExecutionSize" option sets the max number of parallel activity executions allowed
-     * The "setActivityPollThreadCount" option sets the number of simultaneous poll requests on the activity task queue
+     * The "setMaxConcurrentActivityTaskPollers" option sets the number of simultaneous poll requests on activity task queue
      */
     Worker worker =
         factory.newWorker(

--- a/src/main/java/io/temporal/samples/hello/HelloCancellationScope.java
+++ b/src/main/java/io/temporal/samples/hello/HelloCancellationScope.java
@@ -271,7 +271,7 @@ public class HelloCancellationScope {
             TASK_QUEUE,
             WorkerOptions.newBuilder()
                 .setMaxConcurrentActivityExecutionSize(100)
-                .setActivityPollThreadCount(1)
+                .setMaxConcurrentActivityTaskPollers(1)
                 .build());
 
     /*


### PR DESCRIPTION
Signed-off-by: Tihomir Surdilovic <tihomir@temporal.io>

replaces call to setActivityPollThreadCount with setMaxConcurrentActivityTaskPollers