### PR TITLE
Fix build under the latest JDKs by migrating on the spotless plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ This repository contains sample Workflow applications that demonstrate various c
   - [IDE Integration](#ide-integration)
     - [IntelliJ](#intellij)
 
+## Requirements
+
+- Java 1.8+ for build and runtime
+- Java 11+ for development and contribution
+
 ## How to use
 
 1. Clone this repository:

--- a/build.gradle
+++ b/build.gradle
@@ -2,16 +2,11 @@
 
 plugins {
     id 'org.cadixdev.licenser' version '0.6.1'
-    id 'com.github.sherter.google-java-format' version '0.9'
     id "net.ltgt.errorprone" version "3.0.1"
+    id 'com.diffplug.spotless' version '6.11.0' apply false
 }
 
 apply plugin: 'java'
-apply plugin: 'com.github.sherter.google-java-format'
-
-googleJavaFormat {
-    toolVersion (JavaVersion.current().isJava11Compatible() ? '1.15.0' : '1.7')
-}
 
 java {
     sourceCompatibility = JavaVersion.VERSION_1_8
@@ -26,7 +21,7 @@ repositories {
 }
 
 dependencies {
-    implementation(platform("com.fasterxml.jackson:jackson-bom:2.14.0"))
+    implementation(platform("com.fasterxml.jackson:jackson-bom:2.14.1"))
     implementation(platform("io.opentelemetry:opentelemetry-bom:1.20.1"))
     implementation(platform("org.junit:junit-bom:5.9.1"))
 
@@ -62,7 +57,7 @@ dependencies {
     testImplementation("io.temporal:temporal-testing:1.17.0")
 
     testImplementation "junit:junit:4.13.2"
-    testImplementation group: 'org.mockito', name: 'mockito-core', version: '4.8.1'
+    testImplementation group: 'org.mockito', name: 'mockito-core', version: '4.9.0'
     testImplementation group: 'org.powermock', name: 'powermock-api-mockito2', version: '2.0.9'
 
     testImplementation "org.junit.jupiter:junit-jupiter-api"
@@ -79,10 +74,6 @@ dependencies {
     }
 }
 
-compileJava {
-    dependsOn 'googleJavaFormat'
-}
-
 task execute(type: JavaExec) {
     main = findProperty("mainClass") ?: ""
     classpath = sourceSets.main.runtimeClasspath
@@ -96,4 +87,19 @@ license {
     header rootProject.file('license-header.txt')
     exclude '**/*.json'
     exclude '**/*.yml'
+}
+
+if (JavaVersion.current().isJava11Compatible()) {
+    // Code should be formatted using the latest googleJavaFormat, but it doesn't support Java <11 since version 1.8
+    apply plugin: 'com.diffplug.spotless'
+
+    spotless {
+        java {
+            target 'src/*/java/**/*.java'
+            targetExclude '**/.idea/**'
+            googleJavaFormat('1.15.0')
+        }
+    }
+
+    compileJava.dependsOn 'spotlessApply'
 }

--- a/docker/buildkite/Dockerfile
+++ b/docker/buildkite/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:8-focal
+FROM eclipse-temurin:11-focal
 
 # Git is needed in order to update the dls submodule
 RUN apt-get update && apt-get install -y wget protobuf-compiler git

--- a/src/main/java/io/temporal/samples/batch/iterator/IteratorBatchWorkflowImpl.java
+++ b/src/main/java/io/temporal/samples/batch/iterator/IteratorBatchWorkflowImpl.java
@@ -52,10 +52,10 @@ public final class IteratorBatchWorkflowImpl implements IteratorBatchWorkflow {
   @Override
   public int processBatch(int pageSize, int offset) {
     // Loads a page of records
-    List<Record> records = recordLoader.getRecords(pageSize, offset);
+    List<SingleRecord> records = recordLoader.getRecords(pageSize, offset);
     // Starts a child per record asynchrnously.
     List<Promise<Void>> results = new ArrayList<>(records.size());
-    for (Record record : records) {
+    for (SingleRecord record : records) {
       // Uses human friendly child id.
       String childId = Workflow.getInfo().getWorkflowId() + "/" + record.getId();
       RecordProcessorWorkflow processor =

--- a/src/main/java/io/temporal/samples/batch/iterator/RecordLoader.java
+++ b/src/main/java/io/temporal/samples/batch/iterator/RecordLoader.java
@@ -39,5 +39,5 @@ public interface RecordLoader {
    * @param pageSize maximum number of records to return.
    * @return empty list if no more records to process.
    */
-  List<Record> getRecords(int pageSize, int offset);
+  List<SingleRecord> getRecords(int pageSize, int offset);
 }

--- a/src/main/java/io/temporal/samples/batch/iterator/RecordLoaderImpl.java
+++ b/src/main/java/io/temporal/samples/batch/iterator/RecordLoaderImpl.java
@@ -30,11 +30,11 @@ public final class RecordLoaderImpl implements RecordLoader {
   public static final int PAGE_COUNT = 5;
 
   @Override
-  public List<Record> getRecords(int pageSize, int offset) {
-    List<Record> records = new ArrayList<>(pageSize);
+  public List<SingleRecord> getRecords(int pageSize, int offset) {
+    List<SingleRecord> records = new ArrayList<>(pageSize);
     if (offset < pageSize * PAGE_COUNT) {
       for (int i = 0; i < pageSize; i++) {
-        records.add(new Record(offset + i));
+        records.add(new SingleRecord(offset + i));
       }
     }
     return records;

--- a/src/main/java/io/temporal/samples/batch/iterator/RecordProcessorWorkflow.java
+++ b/src/main/java/io/temporal/samples/batch/iterator/RecordProcessorWorkflow.java
@@ -28,5 +28,5 @@ public interface RecordProcessorWorkflow {
 
   /** Processes a single record */
   @WorkflowMethod
-  void processRecord(Record r);
+  void processRecord(SingleRecord r);
 }

--- a/src/main/java/io/temporal/samples/batch/iterator/RecordProcessorWorkflowImpl.java
+++ b/src/main/java/io/temporal/samples/batch/iterator/RecordProcessorWorkflowImpl.java
@@ -30,7 +30,7 @@ public class RecordProcessorWorkflowImpl implements RecordProcessorWorkflow {
   private final Random random = Workflow.newRandom();
 
   @Override
-  public void processRecord(Record r) {
+  public void processRecord(SingleRecord r) {
     // Simulate some processing
     Workflow.sleep(Duration.ofSeconds(random.nextInt(30)));
     log.info("Processed " + r);

--- a/src/main/java/io/temporal/samples/batch/iterator/SingleRecord.java
+++ b/src/main/java/io/temporal/samples/batch/iterator/SingleRecord.java
@@ -20,15 +20,15 @@
 package io.temporal.samples.batch.iterator;
 
 /** Record to process. A real application would add a use case specific data. */
-public class Record {
+public class SingleRecord {
   private int id;
 
-  public Record(int id) {
+  public SingleRecord(int id) {
     this.id = id;
   }
 
   /** JSON deserializer needs it */
-  public Record() {}
+  public SingleRecord() {}
 
   public int getId() {
     return id;
@@ -36,6 +36,6 @@ public class Record {
 
   @Override
   public String toString() {
-    return "Record{" + "id=" + id + '}';
+    return "SingleRecord{" + "id=" + id + '}';
   }
 }

--- a/src/main/java/io/temporal/samples/batch/slidingwindow/SlidingWindowBatchWorkflowImpl.java
+++ b/src/main/java/io/temporal/samples/batch/slidingwindow/SlidingWindowBatchWorkflowImpl.java
@@ -51,7 +51,9 @@ public final class SlidingWindowBatchWorkflowImpl implements SlidingWindowBatchW
   /** Count of completed record processing child workflows. */
   private int progress;
 
-  /** @return number of processed records */
+  /**
+   * @return number of processed records
+   */
   @Override
   public int processBatch(ProcessBatchInput input) {
     WorkflowInfo info = Workflow.getInfo();

--- a/src/test/java/io/temporal/samples/batch/iterator/IteratorIteratorBatchWorkflowTest.java
+++ b/src/test/java/io/temporal/samples/batch/iterator/IteratorIteratorBatchWorkflowTest.java
@@ -36,7 +36,7 @@ public class IteratorIteratorBatchWorkflowTest {
   public static class TestRecordProcessorWorkflowImpl implements RecordProcessorWorkflow {
 
     @Override
-    public void processRecord(Record r) {
+    public void processRecord(SingleRecord r) {
       Workflow.sleep(5000);
       processedRecords[r.getId()] = true;
     }


### PR DESCRIPTION
Build fails right now on Java 17 with unexpected (and incorrect):

```
Detected Java syntax errors in the following files (you can exclude them from this task, see "https://github.com/sherter/google-java-format-gradle-plugin" for details):
```

Migrating to spotless from not supported anymore `com.github.sherter.google-java-format` plugin.
Disable code style check on java <11 as the latest google java format versions require Java 11.  