### PR TITLE
Backporting requirement for higher start to close timeout from #239

### DIFF
--- a/src/main/java/io/temporal/samples/polling/frequent/FrequentPollingWorkflowImpl.java
+++ b/src/main/java/io/temporal/samples/polling/frequent/FrequentPollingWorkflowImpl.java
@@ -37,7 +37,7 @@ public class FrequentPollingWorkflowImpl implements PollingWorkflow {
     ActivityOptions options =
         ActivityOptions.newBuilder()
             // Set activity StartToClose timeout (single activity exec), does not include retries
-            .setStartToCloseTimeout(Duration.ofSeconds(10))
+            .setStartToCloseTimeout(Duration.ofSeconds(60))
             .setHeartbeatTimeout(Duration.ofSeconds(2))
             // For sample we just use the default retry policy (do not set explicitly)
             .build();


### PR DESCRIPTION
From this discussion https://github.com/temporalio/samples-go/pull/246/files#r1071564133 it appears that 10 seconds is an insufficient timeout for the example