### PR TITLE
Empty payload for heartbeating in frequent polling activities

### DIFF
--- a/src/main/java/io/temporal/samples/polling/frequent/FrequentPollingActivityImpl.java
+++ b/src/main/java/io/temporal/samples/polling/frequent/FrequentPollingActivityImpl.java
@@ -49,7 +49,7 @@ public class FrequentPollingActivityImpl implements PollingActivities {
 
       // heart beat and sleep for the poll duration
       try {
-        context.heartbeat(Optional.empty());
+        context.heartbeat(null);
       } catch (ActivityCompletionException e) {
         // activity was either cancelled or workflow was completed or worker shut down
         throw e;

--- a/src/main/java/io/temporal/samples/polling/frequent/FrequentPollingActivityImpl.java
+++ b/src/main/java/io/temporal/samples/polling/frequent/FrequentPollingActivityImpl.java
@@ -24,8 +24,8 @@ import io.temporal.activity.ActivityExecutionContext;
 import io.temporal.client.ActivityCompletionException;
 import io.temporal.samples.polling.PollingActivities;
 import io.temporal.samples.polling.TestService;
-import java.util.concurrent.TimeUnit;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 public class FrequentPollingActivityImpl implements PollingActivities {
   private final TestService service;

--- a/src/main/java/io/temporal/samples/polling/frequent/FrequentPollingActivityImpl.java
+++ b/src/main/java/io/temporal/samples/polling/frequent/FrequentPollingActivityImpl.java
@@ -24,7 +24,6 @@ import io.temporal.activity.ActivityExecutionContext;
 import io.temporal.client.ActivityCompletionException;
 import io.temporal.samples.polling.PollingActivities;
 import io.temporal.samples.polling.TestService;
-import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 public class FrequentPollingActivityImpl implements PollingActivities {

--- a/src/main/java/io/temporal/samples/polling/frequent/FrequentPollingActivityImpl.java
+++ b/src/main/java/io/temporal/samples/polling/frequent/FrequentPollingActivityImpl.java
@@ -25,6 +25,7 @@ import io.temporal.client.ActivityCompletionException;
 import io.temporal.samples.polling.PollingActivities;
 import io.temporal.samples.polling.TestService;
 import java.util.concurrent.TimeUnit;
+import java.util.Optional;
 
 public class FrequentPollingActivityImpl implements PollingActivities {
   private final TestService service;
@@ -48,7 +49,7 @@ public class FrequentPollingActivityImpl implements PollingActivities {
 
       // heart beat and sleep for the poll duration
       try {
-        context.heartbeat("no response");
+        context.heartbeat(Optional.empty());
       } catch (ActivityCompletionException e) {
         // activity was either cancelled or workflow was completed or worker shut down
         throw e;


### PR DESCRIPTION
## What was changed
This pr addresses the optionality of the heartbeat message, as suggested in https://github.com/temporalio/samples-go/pull/246#discussion_r1071570274


## Why?
It the payload is optional, it might be in the future that the workflow engine persistence layer skip a write to the database

