### PR TITLE
Updated README.md to correct default port for Temporal Server from 80…

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ Note that in this case you should use the [Temporal CLI (tctl)](https://docs.tem
 
 ## Temporal Web UI
 
-The Temporal Server running in a docker container includes a Web UI, exposed by default on port 8088 of the docker host.
+The Temporal Server running in a docker container includes a Web UI, exposed by default on port 8080 of the docker host.
 If you are running Docker on your host, you can connect to the WebUI running using a browser and opening the following URI:
 
-[http://localhost:8088](http://localhost:8088)
+[http://localhost:8080](http://localhost:8080)
 
 If you are running Docker on a different host (e.g.: a virtual machine), then modify the URI accordingly by specifying the correct host and the correct port.
 


### PR DESCRIPTION
…88 (old) to 8080 (new)

<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Updated the README.md file to specify the correct default Temporal Sever port (8080).

## Why?
Was working through the hello world and got stuck because I was looking at the old 8088 value, and nothing was running there.  Switched to 8080 and everything worked great :)

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
