### PR TITLE
Gradle 8 - use of 'main' in JavaExec deprecated, should be mainClass

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ Note that in this case you should use the [Temporal CLI (tctl)](https://docs.tem
 
 ## Temporal Web UI
 
-The Temporal Server running in a docker container includes a Web UI, exposed by default on port 8088 of the docker host.
+The Temporal Server running in a docker container includes a Web UI, exposed by default on port 8080 of the docker host.
 If you are running Docker on your host, you can connect to the WebUI running using a browser and opening the following URI:
 
-[http://localhost:8088](http://localhost:8088)
+[http://localhost:8080](http://localhost:8080)
 
 If you are running Docker on a different host (e.g.: a virtual machine), then modify the URI accordingly by specifying the correct host and the correct port.
 

--- a/build.gradle
+++ b/build.gradle
@@ -79,7 +79,7 @@ dependencies {
 }
 
 task execute(type: JavaExec) {
-    main = findProperty("mainClass") ?: ""
+    mainClass = findProperty("mainClass") ?: ""
     classpath = sourceSets.main.runtimeClasspath
 }
 


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
1) Updated README.md to use port 8080 instead of 8088 (this pull request seems to be adding both these changes, this one was approved previously in PR 425 (sorry for the duplication I'm still learning)
2) Updated build.gradel to use 'mainClass' instead of 'main' in JavaExec 

## Why?
Use of 'main' had been deprecated in Gradle 8, see here for details: https://docs.gradle.org/7.4.2/dsl/org.gradle.api.tasks.JavaExec.html#org.gradle.api.tasks.JavaExec:main

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
Ran HelloWorld (samples-java) example on my local workstation successfully

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
