### PR TITLE
adding 'ui' to springboot samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,15 @@ See the README.md file in each main sample directory for cut/paste Gradle comman
 <!-- @@@SNIPEND -->
 
 ### Running SpringBoot Samples
-See the README.md file in each main sample directory for cut/paste Gradle command to run specific example.
 
+1. Start SpringBoot from main repo dir:
+
+       ./gradlew bootRun
+
+2. Navigate to [localhost:3030](http://localhost:3030)
+
+3. Select which sample you want to run
+
+More info on each sample:
 - [**Hello**](/springboot/src/main/java/io/temporal/samples/springboot/hello): Invoke simple "Hello" workflow from a GET endpoint
     

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ subprojects {
         exclude '**/*.json'
         exclude '**/*.yaml'
         exclude '**/*.yml'
+        exclude '**/*.html'
     }
 
     if (JavaVersion.current().isJava11Compatible()) {

--- a/springboot/build.gradle
+++ b/springboot/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'org.springframework.boot'
 
 dependencies {
     implementation "org.springframework.boot:spring-boot-starter-web"
+    implementation "org.springframework.boot:spring-boot-starter-thymeleaf"
     implementation "org.springframework.boot:spring-boot-starter-actuator"
     implementation "io.temporal:temporal-spring-boot-starter-alpha:$javaSDKVersion"
     testImplementation "org.springframework.boot:spring-boot-starter-test"

--- a/springboot/src/main/java/io/temporal/samples/springboot/SamplesController.java
+++ b/springboot/src/main/java/io/temporal/samples/springboot/SamplesController.java
@@ -22,18 +22,31 @@ package io.temporal.samples.springboot;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.samples.springboot.hello.HelloWorkflow;
+import io.temporal.samples.springboot.hello.model.Person;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
 
-@RestController
+@Controller
 public class SamplesController {
 
   @Autowired WorkflowClient client;
 
-  @GetMapping("/hello/{name}")
-  String helloSample(@PathVariable String name) {
+  @GetMapping("/hello")
+  public String hello(Model model) {
+    model.addAttribute("sample", "Say Hello");
+    return "hello";
+  }
+
+  @PostMapping(
+      value = "/hello",
+      consumes = {MediaType.APPLICATION_JSON_VALUE},
+      produces = {MediaType.TEXT_HTML_VALUE})
+  ResponseEntity helloSample(@RequestBody Person person) {
     HelloWorkflow workflow =
         client.newWorkflowStub(
             HelloWorkflow.class,
@@ -42,6 +55,7 @@ public class SamplesController {
                 .setWorkflowId("HelloSample")
                 .build());
 
-    return workflow.sayHello(name);
+    // bypass thymeleaf, don't return template name just result
+    return new ResponseEntity("\"" + workflow.sayHello(person) + "\"", HttpStatus.OK);
   }
 }

--- a/springboot/src/main/java/io/temporal/samples/springboot/hello/HelloActivity.java
+++ b/springboot/src/main/java/io/temporal/samples/springboot/hello/HelloActivity.java
@@ -20,8 +20,9 @@
 package io.temporal.samples.springboot.hello;
 
 import io.temporal.activity.ActivityInterface;
+import io.temporal.samples.springboot.hello.model.Person;
 
 @ActivityInterface
 public interface HelloActivity {
-  String hello(String name);
+  String hello(Person person);
 }

--- a/springboot/src/main/java/io/temporal/samples/springboot/hello/HelloActivityImpl.java
+++ b/springboot/src/main/java/io/temporal/samples/springboot/hello/HelloActivityImpl.java
@@ -19,6 +19,7 @@
 
 package io.temporal.samples.springboot.hello;
 
+import io.temporal.samples.springboot.hello.model.Person;
 import io.temporal.spring.boot.ActivityImpl;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -30,8 +31,8 @@ public class HelloActivityImpl implements HelloActivity {
   private String language;
 
   @Override
-  public String hello(String name) {
+  public String hello(Person person) {
     String greeting = language.equals("spanish") ? "Hola " : "Hello ";
-    return greeting + name + "!";
+    return greeting + person.getFirstName() + " " + person.getLastName() + "!";
   }
 }

--- a/springboot/src/main/java/io/temporal/samples/springboot/hello/HelloWorkflow.java
+++ b/springboot/src/main/java/io/temporal/samples/springboot/hello/HelloWorkflow.java
@@ -19,11 +19,12 @@
 
 package io.temporal.samples.springboot.hello;
 
+import io.temporal.samples.springboot.hello.model.Person;
 import io.temporal.workflow.WorkflowInterface;
 import io.temporal.workflow.WorkflowMethod;
 
 @WorkflowInterface
 public interface HelloWorkflow {
   @WorkflowMethod
-  String sayHello(String message);
+  String sayHello(Person person);
 }

--- a/springboot/src/main/java/io/temporal/samples/springboot/hello/README.md
+++ b/springboot/src/main/java/io/temporal/samples/springboot/hello/README.md
@@ -6,10 +6,11 @@
 
 2. In your browser navigate to:
  
-       http://localhost:3030/hello/Temporal%20User
+       http://localhost:3030/hello
 
-You should see "Hello Temporal User!" show on the page which is the result of our 
-Hello workflow execution.
+Enter in first and last name in the form then click on Run Workflow
+to start workflow execution. Page will be updated to show the workflow
+execution results (the greeting).
 
 You can try changing the language setting in [application.yaml](../../../../../../resources/application.yaml) file
 from "english" to "spanish" to get the greeting result in Spanish.

--- a/springboot/src/main/java/io/temporal/samples/springboot/hello/model/Person.java
+++ b/springboot/src/main/java/io/temporal/samples/springboot/hello/model/Person.java
@@ -17,24 +17,33 @@
  *  permissions and limitations under the License.
  */
 
-package io.temporal.samples.springboot.hello;
+package io.temporal.samples.springboot.hello.model;
 
-import io.temporal.activity.ActivityOptions;
-import io.temporal.samples.springboot.hello.model.Person;
-import io.temporal.spring.boot.WorkflowImpl;
-import io.temporal.workflow.Workflow;
-import java.time.Duration;
+public class Person {
+  private String firstName;
+  private String lastName;
 
-@WorkflowImpl(taskQueues = "HelloSampleTaskQueue")
-public class HelloWorkflowImpl implements HelloWorkflow {
+  public Person() {}
+  ;
 
-  private HelloActivity activity =
-      Workflow.newActivityStub(
-          HelloActivity.class,
-          ActivityOptions.newBuilder().setStartToCloseTimeout(Duration.ofSeconds(2)).build());
+  public Person(String firstName, String lastName) {
+    this.firstName = firstName;
+    this.lastName = lastName;
+  }
 
-  @Override
-  public String sayHello(Person person) {
-    return activity.hello(person);
+  public String getFirstName() {
+    return firstName;
+  }
+
+  public void setFirstName(String firstName) {
+    this.firstName = firstName;
+  }
+
+  public String getLastName() {
+    return lastName;
+  }
+
+  public void setLastName(String lastName) {
+    this.lastName = lastName;
   }
 }

--- a/springboot/src/main/resources/templates/hello.html
+++ b/springboot/src/main/resources/templates/hello.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <link rel="stylesheet"
+          href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/css/bootstrap.min.css"/>
+    <link rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/prism/9000.0.1/themes/prism.min.css"/>
+    <link href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@1,400;1,700&display=swap" rel="stylesheet">
+    <script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/js/bootstrap.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/9000.0.1/prism.min.js"></script>
+</head>
+<body>
+<div class="container">
+    <div class="card">
+        <div class="card-body">
+            <h4 class="card-title" th:text="'Temporal Java SDK Samples: ' + ${sample}">Temporal Java SDK Samples</h4>
+            <h6>This is a simple greeting example. Enter persons first and last name then submit form to start
+            workflow execution. Results will be updated on the page.</h6>
+            <div class="form-group">
+                <br/><br/><br/>
+                <h5>Enter greeting:</h5>
+                <form action="/hello", id="sampleform">
+                    <p>First Name: <input type="text" name="firstName"/></p>
+                    <p>Last Name: <input type="text" name="lastName"/></p>
+                    <p><input type="submit" value="Run Workflow" class="btn btn-primary" />
+                        <input type="reset" value="Reset Form" class="btn btn-secondary" />
+                </form>
+            </div>
+        </div>
+        <div style="width: 18rem;">
+            <div>
+                <h5 class="card-title">Workflow result:</h5>
+                <div id="result"></div>
+            </div>
+        </div>
+    </div>
+</div>
+<script>
+$("#sampleform").submit(function( event ) {
+    event.preventDefault();
+
+    var $form = $( this ),
+        firstName = $form.find( "input[name='firstName']" ).val(),
+        lastName = $form.find( "input[name='lastName']" ).val(),
+        url = $form.attr( "action" );
+
+    $.ajax({
+        'url': url,
+        'method':'POST',
+        'dataType': 'json',
+        'contentType': 'application/json',
+        'data':JSON.stringify({
+            "firstName": firstName,
+            "lastName": lastName
+        }),
+        success: function(response) {
+            $( "#result" ).empty().append( response );
+        }
+    });
+});
+</script>
+</body>
+</html>

--- a/springboot/src/main/resources/templates/hello.html
+++ b/springboot/src/main/resources/templates/hello.html
@@ -20,7 +20,7 @@
             workflow execution. Results will be updated on the page.</h6>
             <div class="form-group">
                 <br/><br/><br/>
-                <h5>Enter greeting:</h5>
+                <h5>Say hello to:</h5>
                 <form action="/hello", id="sampleform">
                     <p>First Name: <input type="text" name="firstName"/></p>
                     <p>Last Name: <input type="text" name="lastName"/></p>

--- a/springboot/src/main/resources/templates/index.html
+++ b/springboot/src/main/resources/templates/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <link rel="stylesheet"
+          href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/css/bootstrap.min.css"/>
+    <link rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/prism/9000.0.1/themes/prism.min.css"/>
+    <link href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@1,400;1,700&display=swap" rel="stylesheet">
+    <script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/js/bootstrap.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/9000.0.1/prism.min.js"></script>
+</head>
+<body>
+<div class="container">
+    <div class="card">
+        <div class="card-body">
+            <h5 class="card-title">Temporal Java SDK Samples</h5>
+            <p class="card-text">Click on sample link to run it.</p>
+            <div class="list-group">
+                <a href="/hello" class="list-group-item list-group-item-action">Say Hello</a>
+            </div>
+        </div>
+    </div>
+
+</div>
+</body>
+</html>

--- a/springboot/src/test/java/io/temporal/samples/springboot/HelloSampleTest.java
+++ b/springboot/src/test/java/io/temporal/samples/springboot/HelloSampleTest.java
@@ -22,6 +22,7 @@ package io.temporal.samples.springboot;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowOptions;
 import io.temporal.samples.springboot.hello.HelloWorkflow;
+import io.temporal.samples.springboot.hello.model.Person;
 import io.temporal.testing.TestWorkflowEnvironment;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -56,7 +57,7 @@ public class HelloSampleTest {
                 .setTaskQueue("HelloSampleTaskQueue")
                 .setWorkflowId("HelloSampleTest")
                 .build());
-    String result = workflow.sayHello("Temporal User");
+    String result = workflow.sayHello(new Person("Temporal", "User"));
     Assert.notNull(result, "Greeting should not be null");
     Assert.isTrue(result.equals("Hello Temporal User!"), "Invalid result");
   }


### PR DESCRIPTION
Adding 'ui' (html pages) for spring boot samples (ok just one sample but adding more :) )
Users can now just start spring boot:

          ./gradlew bootRun

and then go to localhost:3030 to see page with all samples and then click on each sample to get to page for that sample.
for example for "hello" one:

<img width="1132" alt="Screen Shot 2023-06-19 at 5 19 29 PM" src="https://github.com/temporalio/samples-java/assets/119422/8205e512-3611-4cf5-9a35-2f09c575348c">


Sample form:

<img width="1309" alt="Screen Shot 2023-06-19 at 5 19 37 PM" src="https://github.com/temporalio/samples-java/assets/119422/9de6de32-20c7-41ec-972e-33443cdba65b">


After entering values and running wf:

<img width="1361" alt="Screen Shot 2023-06-19 at 5 19 47 PM" src="https://github.com/temporalio/samples-java/assets/119422/d30ee88b-13df-41f4-b00a-4f86608f0d4c">





