### PR TITLE
spring boot samples - sdk metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,4 +140,5 @@ See the README.md file in each main sample directory for cut/paste Gradle comman
 
 More info on each sample:
 - [**Hello**](/springboot/src/main/java/io/temporal/samples/springboot/hello): Invoke simple "Hello" workflow from a GET endpoint
+- [**SDK Metrics**](/springboot/src/main/java/io/temporal/samples/springboot/metrics): Learn how to set up SDK Metrics
     

--- a/springboot/build.gradle
+++ b/springboot/build.gradle
@@ -5,6 +5,7 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-thymeleaf"
     implementation "org.springframework.boot:spring-boot-starter-actuator"
     implementation "io.temporal:temporal-spring-boot-starter-alpha:$javaSDKVersion"
+    runtimeOnly "io.micrometer:micrometer-registry-prometheus"
     testImplementation "org.springframework.boot:spring-boot-starter-test"
     dependencies {
         errorproneJavac('com.google.errorprone:javac:9+181-r4173-1')

--- a/springboot/src/main/java/io/temporal/samples/springboot/SamplesController.java
+++ b/springboot/src/main/java/io/temporal/samples/springboot/SamplesController.java
@@ -58,4 +58,10 @@ public class SamplesController {
     // bypass thymeleaf, don't return template name just result
     return new ResponseEntity("\"" + workflow.sayHello(person) + "\"", HttpStatus.OK);
   }
+
+  @GetMapping("/metrics")
+  public String metrics(Model model) {
+    model.addAttribute("sample", "SDK Metrics");
+    return "metrics";
+  }
 }

--- a/springboot/src/main/java/io/temporal/samples/springboot/metrics/README.md
+++ b/springboot/src/main/java/io/temporal/samples/springboot/metrics/README.md
@@ -1,0 +1,13 @@
+# SpringBoot Metrics Sample
+
+1. Start SpringBoot from main samples repo directory:
+   
+       ./gradlew bootRun
+
+2. In your browser navigate to:
+ 
+       http://localhost:3030/metrics
+
+This sample involves just SpringBoot and Actuator configurations which are 
+included in the samples already. The page shows information on how to set up
+SDK metrics in your SpringBoot applications. 

--- a/springboot/src/main/resources/application.yaml
+++ b/springboot/src/main/resources/application.yaml
@@ -3,6 +3,7 @@ server:
 spring:
   application:
     name: temporal-samples
+  # temporal specific configs
   temporal:
     connection:
       target: 127.0.0.1:7233
@@ -21,6 +22,13 @@ spring:
 #      max-threads: 10
     workersAutoDiscovery:
       packages: io.temporal.samples.springboot
+# actuator (sdk metrics)
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus
+# specific for samples
 samples:
   data:
     language: english

--- a/springboot/src/main/resources/templates/index.html
+++ b/springboot/src/main/resources/templates/index.html
@@ -20,6 +20,9 @@
             <div class="list-group">
                 <a href="/hello" class="list-group-item list-group-item-action">Say Hello</a>
             </div>
+            <div class="list-group">
+                <a href="/metrics" class="list-group-item list-group-item-action">SDK Metrics</a>
+            </div>
         </div>
     </div>
 

--- a/springboot/src/main/resources/templates/metrics.html
+++ b/springboot/src/main/resources/templates/metrics.html
@@ -55,7 +55,7 @@
                             <h5 class="mb-1">3. View metrics (Prometheus format)</h5>
                         </div>
                         <p>Actuator will expose SDK metrics automatically.<br/>
-                            You can access raw metrics at localhost:3030/actuator/prometheus".<br/>
+                            You can access raw metrics at "localhost:3030/actuator/prometheus".<br/>
                             This is already set up for the samples project.
                         </p>
                         <small class="text-muted">You can set up Prometheus config to scrape SDK metrics from this endpoint.</small>

--- a/springboot/src/main/resources/templates/metrics.html
+++ b/springboot/src/main/resources/templates/metrics.html
@@ -39,7 +39,7 @@
                     </a>
                     <a href="#" class="list-group-item list-group-item-action flex-column align-items-start">
                         <div class="d-flex w-100 justify-content-between">
-                            <h5 class="mb-1">3. Add micrometer-registry-prometheus as runtime dependency</h5>
+                            <h5 class="mb-1">2. Add micrometer-registry-prometheus as runtime dependency</h5>
                         </div>
                         <p class="mb-1">
                         <pre><code>Gradle:

--- a/springboot/src/main/resources/templates/metrics.html
+++ b/springboot/src/main/resources/templates/metrics.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/html">
+<head>
+    <link rel="stylesheet"
+          href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/css/bootstrap.min.css"/>
+    <link rel="stylesheet"
+          href="https://cdnjs.cloudflare.com/ajax/libs/prism/9000.0.1/themes/prism.min.css"/>
+    <link href="https://fonts.googleapis.com/css2?family=Lato:ital,wght@1,400;1,700&display=swap" rel="stylesheet">
+    <script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.11.0/umd/popper.min.js"></script>
+    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.0/js/bootstrap.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/9000.0.1/prism.min.js"></script>
+</head>
+<body>
+<div class="container">
+    <div class="card">
+        <div class="card-body">
+            <h4 class="card-title" th:text="'Temporal Java SDK Samples: ' + ${sample}">Temporal Java SDK Samples</h4>
+            <h6>In this sample we show how to set up and consume SDK metrics.</h6>
+            <br/><br/><br/>
+            <div>
+                <h6>Configuring SDK metrics is super easy using <a href="https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html" target="_blank">Spring Actuator</a></h6><br/>
+                <div class="list-group">
+                    <a href="#" class="list-group-item list-group-item-action flex-column align-items-start">
+                        <div class="d-flex w-100 justify-content-between">
+                            <h5 class="mb-1">1. Add spring-boot-starter-actuator to project dependencies</h5>
+                        </div>
+                        <p class="mb-1">
+                        <pre><code>Gradle:
+                        <br/> implementation "org.springframework.boot:spring-boot-starter-actuator"
+                         </code></pre>
+                        <pre><code>Maven:
+                        <br/> &lt;dependency&gt;
+   &lt;groupId&gt;org.springframework.boot&lt;/groupId&gt;
+   &lt;artifactId&gt;spring-boot-starter-actuator&lt;/artifactId&gt;
+ &lt;/dependency&gt;
+                         </code></pre>
+                        </p>
+                    </a>
+                    <a href="#" class="list-group-item list-group-item-action flex-column align-items-start">
+                        <div class="d-flex w-100 justify-content-between">
+                            <h5 class="mb-1">2. Configure Actuator in application properties/yaml</h5>
+                        </div>
+                        <p class="mb-1">
+                        <pre><code>management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus
+                         </code></pre>
+                         <small class="text-muted">Alternatively, you can define a custom io.micrometer.core.instrument.MeterRegistry bean in the application context.</small>
+                    </a>
+                    <a href="#" class="list-group-item list-group-item-action flex-column align-items-start">
+                        <div class="d-flex w-100 justify-content-between">
+                            <h5 class="mb-1">3. View metrics (Prometheus format)</h5>
+                        </div>
+                        <p>Actuator will expose SDK metrics automatically.<br/>
+                            You can access raw metrics at localhost:3030/actuator/prometheus".<br/>
+                            This is already set up for the samples project.
+                        </p>
+                        <small class="text-muted">You can set up Prometheus config to scrape SDK metrics from this endpoint.</small>
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/springboot/src/main/resources/templates/metrics.html
+++ b/springboot/src/main/resources/templates/metrics.html
@@ -39,7 +39,24 @@
                     </a>
                     <a href="#" class="list-group-item list-group-item-action flex-column align-items-start">
                         <div class="d-flex w-100 justify-content-between">
-                            <h5 class="mb-1">2. Configure Actuator in application properties/yaml</h5>
+                            <h5 class="mb-1">3. Add micrometer-registry-prometheus as runtime dependency</h5>
+                        </div>
+                        <p class="mb-1">
+                        <pre><code>Gradle:
+                        <br/> runtimeOnly "io.micrometer:micrometer-registry-prometheus"
+                         </code></pre>
+                        <pre><code>Maven:
+                        <br/> &lt;dependency&gt;
+   &lt;groupId>io.micrometer&lt;/groupId&gt;
+   &lt;artifactId>micrometer-registry-prometheus&lt;/artifactId&gt;
+   &lt;scope>runtime&lt;/scope&gt;
+ &lt;/dependency>
+                         </code></pre>
+                        </p>
+                    </a>
+                    <a href="#" class="list-group-item list-group-item-action flex-column align-items-start">
+                        <div class="d-flex w-100 justify-content-between">
+                            <h5 class="mb-1">3. Configure Actuator in application properties/yaml</h5>
                         </div>
                         <p class="mb-1">
                         <pre><code>management:
@@ -52,7 +69,7 @@
                     </a>
                     <a href="#" class="list-group-item list-group-item-action flex-column align-items-start">
                         <div class="d-flex w-100 justify-content-between">
-                            <h5 class="mb-1">3. View metrics (Prometheus format)</h5>
+                            <h5 class="mb-1">4. View metrics (Prometheus format)</h5>
                         </div>
                         <p>Actuator will expose SDK metrics automatically.<br/>
                             You can access raw metrics at "localhost:3030/actuator/prometheus".<br/>


### PR DESCRIPTION
This shows users how easy it is to set up sdk metrics with spring boot and actuator.

There is no code for this sample. Just update to application.yaml to set up actuator endpoint
and page that shows users how to do this and also link to endpoint where they can see their metrics (this is set up when 
you start spring boot in samples already so nothing to do really)

/metrics endpoint:

<img width="777" alt="Screen Shot 2023-06-20 at 11 42 41 AM" src="https://github.com/temporalio/samples-java/assets/119422/b255bddf-34f7-40bd-aff3-4a3442693e9a">

