### PR TITLE
SpringBoot - Kafka Sample

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'org.cadixdev.licenser' version '0.6.1'
     id "net.ltgt.errorprone" version "3.1.0"
     id 'com.diffplug.spotless' version '6.17.0' apply false
-    id 'org.springframework.boot' version '2.7.12'
+    id 'org.springframework.boot' version '2.7.13'
 }
 
 subprojects {
@@ -39,6 +39,7 @@ subprojects {
         exclude '**/*.yaml'
         exclude '**/*.yml'
         exclude '**/*.html'
+        exclude '**/*.js'
     }
 
     if (JavaVersion.current().isJava11Compatible()) {

--- a/springboot/build.gradle
+++ b/springboot/build.gradle
@@ -5,6 +5,9 @@ dependencies {
     implementation "org.springframework.boot:spring-boot-starter-thymeleaf"
     implementation "org.springframework.boot:spring-boot-starter-actuator"
     implementation "org.springframework.boot:spring-boot-starter-data-jpa"
+    implementation "org.springframework.kafka:spring-kafka"
+    // we set this as impl depends to use embedded kafka in samples not just tests
+    implementation "org.springframework.kafka:spring-kafka-test"
     implementation "io.temporal:temporal-spring-boot-starter-alpha:$javaSDKVersion"
     runtimeOnly "io.micrometer:micrometer-registry-prometheus"
     runtimeOnly "com.h2database:h2"

--- a/springboot/src/main/java/io/temporal/samples/springboot/kafka/KafkaActivity.java
+++ b/springboot/src/main/java/io/temporal/samples/springboot/kafka/KafkaActivity.java
@@ -1,0 +1,27 @@
+/*
+ *  Copyright (c) 2020 Temporal Technologies, Inc. All Rights Reserved
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.samples.springboot.kafka;
+
+import io.temporal.activity.ActivityInterface;
+
+@ActivityInterface
+public interface KafkaActivity {
+  void sendMessage(String message);
+}

--- a/springboot/src/main/java/io/temporal/samples/springboot/kafka/KafkaActivityImpl.java
+++ b/springboot/src/main/java/io/temporal/samples/springboot/kafka/KafkaActivityImpl.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c) 2020 Temporal Technologies, Inc. All Rights Reserved
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.samples.springboot.kafka;
+
+import io.temporal.spring.boot.ActivityImpl;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@ActivityImpl(taskQueues = "KafkaSampleTaskQueue")
+public class KafkaActivityImpl implements KafkaActivity {
+
+  // Setting required to false means we won't fail
+  // if a test does not have kafka enabled
+  @Autowired(required = false)
+  private KafkaTemplate<String, String> kafkaTemplate;
+
+  @Value(value = "${samples.message.topic.name}")
+  private String topicName;
+
+  @Override
+  public void sendMessage(String message) {
+    kafkaTemplate.send(topicName, message);
+  }
+}

--- a/springboot/src/main/java/io/temporal/samples/springboot/kafka/KafkaConfig.java
+++ b/springboot/src/main/java/io/temporal/samples/springboot/kafka/KafkaConfig.java
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (c) 2020 Temporal Technologies, Inc. All Rights Reserved
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.samples.springboot.kafka;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.core.KafkaAdmin;
+import org.springframework.kafka.test.EmbeddedKafkaBroker;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@Configuration()
+@Profile("!test")
+public class KafkaConfig {
+  @Value(value = "${spring.kafka.bootstrap-servers}")
+  private String bootstrapAddress;
+
+  @Value(value = "${samples.message.topic.name}")
+  private String topicName;
+
+  @Autowired private MessageController messageController;
+
+  @Bean
+  EmbeddedKafkaBroker broker() {
+    return new EmbeddedKafkaBroker(1)
+        .kafkaPorts(9092)
+        .brokerListProperty("spring.kafka.bootstrap-servers");
+  }
+
+  @Bean
+  public KafkaAdmin kafkaAdmin() {
+    Map<String, Object> configs = new HashMap<>();
+    configs.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapAddress);
+    return new KafkaAdmin(configs);
+  }
+
+  @Bean
+  public NewTopic samplesTopic() {
+    return new NewTopic(topicName, 1, (short) 1);
+  }
+
+  @KafkaListener(id = "samples-topic", topics = "samples-topic")
+  public void kafkaListener(String message) {
+    SseEmitter latestEm = messageController.getLatestEmitter();
+
+    try {
+      latestEm.send(message);
+    } catch (IOException e) {
+      latestEm.completeWithError(e);
+    }
+  }
+}

--- a/springboot/src/main/java/io/temporal/samples/springboot/kafka/MessageController.java
+++ b/springboot/src/main/java/io/temporal/samples/springboot/kafka/MessageController.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2020 Temporal Technologies, Inc. All Rights Reserved
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.samples.springboot.kafka;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+public class MessageController {
+  private final List<SseEmitter> emitters = new ArrayList<>();
+
+  @GetMapping("/kafka-messages")
+  public SseEmitter getKafkaMessages() {
+
+    SseEmitter emitter = new SseEmitter(60 * 1000L);
+    emitters.add(emitter);
+
+    emitter.onCompletion(() -> emitters.remove(emitter));
+
+    emitter.onTimeout(() -> emitters.remove(emitter));
+
+    return emitter;
+  }
+
+  public List<SseEmitter> getEmitters() {
+    return emitters;
+  }
+
+  public SseEmitter getLatestEmitter() {
+    return (emitters.isEmpty()) ? null : emitters.get(emitters.size() - 1);
+  }
+}

--- a/springboot/src/main/java/io/temporal/samples/springboot/kafka/MessageWorkflow.java
+++ b/springboot/src/main/java/io/temporal/samples/springboot/kafka/MessageWorkflow.java
@@ -1,0 +1,34 @@
+/*
+ *  Copyright (c) 2020 Temporal Technologies, Inc. All Rights Reserved
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.samples.springboot.kafka;
+
+import io.temporal.workflow.SignalMethod;
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
+
+@WorkflowInterface
+public interface MessageWorkflow {
+
+  @WorkflowMethod
+  void start();
+
+  @SignalMethod
+  void update(String message);
+}

--- a/springboot/src/main/java/io/temporal/samples/springboot/kafka/MessageWorkflowImpl.java
+++ b/springboot/src/main/java/io/temporal/samples/springboot/kafka/MessageWorkflowImpl.java
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2020 Temporal Technologies, Inc. All Rights Reserved
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.samples.springboot.kafka;
+
+import io.temporal.activity.ActivityOptions;
+import io.temporal.spring.boot.WorkflowImpl;
+import io.temporal.workflow.Workflow;
+import java.time.Duration;
+
+@WorkflowImpl(taskQueues = "KafkaSampleTaskQueue")
+public class MessageWorkflowImpl implements MessageWorkflow {
+
+  private KafkaActivity activity =
+      Workflow.newActivityStub(
+          KafkaActivity.class,
+          ActivityOptions.newBuilder().setStartToCloseTimeout(Duration.ofSeconds(2)).build());
+  private String message = null;
+
+  @Override
+  public void start() {
+    Workflow.await(() -> message != null);
+    // simulate some steps / milestones
+    activity.sendMessage(
+        "Starting execution: " + Workflow.getInfo().getWorkflowId() + " with message: " + message);
+
+    activity.sendMessage("Step 1 done...");
+    activity.sendMessage("Step 2 done...");
+    activity.sendMessage("Step 3 done...");
+
+    activity.sendMessage("Completing execution: " + Workflow.getInfo().getWorkflowId());
+  }
+
+  @Override
+  public void update(String message) {
+    this.message = message;
+  }
+}

--- a/springboot/src/main/java/io/temporal/samples/springboot/kafka/README.md
+++ b/springboot/src/main/java/io/temporal/samples/springboot/kafka/README.md
@@ -1,0 +1,32 @@
+# SpringBoot Kafka Request / Reply Sample
+
+1. Start SpringBoot from main samples repo directory:
+
+       ./gradlew bootRun
+
+2. In your browser navigate to:
+
+       http://localhost:3030/kafka
+
+## Use Case
+When you start adopting Temporal in your existing applications it can 
+very often become a much better replacement to any queueing techs like Kafka.
+Even tho we can replace big parts of our unreliable architecture with Temporal
+often it's not a complete replacement and we still have services that produce 
+messages/events to Kafka topics and workflow results need to be pushed to Kafka in order
+to be consumed by these existing services.
+In this sample we show how messages sent to Kafka topics can trigger workflow execution
+as well as how via activities we can produce messages to Kafka topics that can be consumed
+by other existing services you might have. 
+
+## How to use
+Enter a message you want to set to Kafka topic. Message consumer when it receives it 
+will start a workflow execution and deliver message to it as signal. 
+Workflow execution performs some sample steps. For each step it executes an activity which uses
+Kafka producer to send message to Kafka topic. 
+In the UI we listen on this kafka topic and you will see all messages produced by activities
+show up dynamically as they are happening.
+
+## Note
+We use embedded (in-memory) Kafka to make it easier to run this sample.
+You should not use this in your applications outside of tests. 

--- a/springboot/src/main/resources/application.yaml
+++ b/springboot/src/main/resources/application.yaml
@@ -1,6 +1,8 @@
 server:
   port: 3030
 spring:
+  main:
+    allow-bean-definition-overriding: true
   application:
     name: temporal-samples
   # temporal specific configs
@@ -37,6 +39,11 @@ spring:
   h2:
     console:
       enabled: true
+  ## kafka setup for samples
+  kafka:
+    consumer:
+      auto-offset-reset: earliest
+    bootstrap-servers: localhost:9092
 # actuator (sdk metrics)
 management:
   endpoints:
@@ -47,3 +54,8 @@ management:
 samples:
   data:
     language: english
+  message:
+    topic:
+      name: samples-topic
+    group:
+      name: samples-group

--- a/springboot/src/main/resources/static/js/jquery.sse.js
+++ b/springboot/src/main/resources/static/js/jquery.sse.js
@@ -1,0 +1,199 @@
+/*
+ * jQuery Plugin for Server-Sent Events (SSE) EventSource Polyfill v0.1.3
+ * https://github.com/byjg/jquery-sse
+ *
+ * This document is licensed as free software under the terms of the
+ * MIT License: http://www.opensource.org/licenses/mit-license.php
+ *
+ * Copyright (c) 2015 by JG (João Gilberto Magalhães).
+ */
+(function ($) {
+    $.extend({
+        SSE: function (url, customSettings) {
+            var sse = {instance: null, type: null};
+
+            var settings = {
+                onOpen: function (e) {
+                },
+                onEnd: function (e) {
+                },
+                onError: function (e) {
+                },
+                onMessage: function (e) {
+                },
+                options: {},
+                headers: {},
+                events: {}
+            };
+
+            $.extend(settings, customSettings);
+
+            sse._url = url;
+            sse._settings = settings;
+
+            // Start the proper EventSource object or Ajax fallback
+            sse._start = sse.start;
+            sse.start = function () {
+                if (this.instance) {
+                    return false;
+                }
+
+                if (!window.EventSource || this._settings.options.forceAjax || (Object.keys(this._settings.headers).length > 0)) {
+                    createAjax(this);
+                } else {
+                    createEventSource(this);
+                }
+
+                return true;
+            };
+
+            // Stop the proper object
+            sse.stop = function () {
+                if (!this.instance) {
+                    return false;
+                }
+
+                if (!window.EventSource || this._settings.options.forceAjax || (Object.keys(this._settings.headers).length > 0)) {
+                    // Nothing to do;
+                } else {
+                    this.instance.close();
+                }
+                this._settings.onEnd();
+
+                this.instance = null;
+                this.type = null;
+
+                return true;
+
+            };
+
+            return sse;
+
+        }
+    });
+
+
+    // Private Method for Handle EventSource object
+    function createEventSource(me) {
+        me.type = 'event';
+        me.instance = new EventSource(me._url);
+        me.instance.successCount = 0;
+
+        me.instance.onmessage = me._settings.onMessage;
+        me.instance.onopen = function (e) {
+            if (me.instance.successCount++ === 0) {
+                me._settings.onOpen(e);
+            }
+        };
+        me.instance.onerror = function (e) {
+            if (e.target.readyState === EventSource.CLOSED) {
+                me._settings.onError(e);
+            }
+        };
+
+        for (var key in me._settings.events) {
+            me.instance.addEventListener(key, me._settings.events[key], false);
+        }
+    }
+
+    // Handle the Ajax instance (fallback)
+    function createAjax(me) {
+        me.type = 'ajax';
+        me.instance = {successCount: 0, id: null, retry: 3000, data: "", event: ""};
+        runAjax(me);
+    }
+
+    // Handle the continous Ajax request (fallback)
+    function runAjax(me) {
+        if (!me.instance) {
+            return;
+        }
+
+        var headers = {'Last-Event-ID': me.instance.id};
+
+        $.extend(headers, me._settings.headers);
+
+        $.ajax({
+            url: me._url,
+            method: 'GET',
+            headers: headers,
+            success: function (receivedData, status, info) {
+                if (!me.instance) {
+                    return;
+                }
+
+                if (me.instance.successCount++ === 0) {
+                    me._settings.onOpen();
+                }
+
+                var lines = receivedData.split("\n");
+
+                // Process the return to generate a compatible SSE response
+                me.instance.data = "";
+                var countBreakLine = 0;
+                for (var key in lines) {
+                    var separatorPos = lines[key].indexOf(":");
+                    var item = [
+                        lines[key].substr(0, separatorPos),
+                        lines[key].substr(separatorPos + 1)
+                    ];
+                    switch (item[0]) {
+                        // If the first part is empty, needed to check another sequence
+                        case "":
+                            if (!item[1] && countBreakLine++ === 1) {  // Avoid comments!
+                                eventMessage = {
+                                    data: me.instance.data,
+                                    lastEventId: me.instance.id,
+                                    origin: 'http://' + info.getResponseHeader('Host'),
+                                    returnValue: true
+                                };
+
+                                // If there are a custom event then call it
+                                if (me.instance.event && me._settings.events[me.instance.event]) {
+                                    me._settings.events[me.instance.event](eventMessage);
+                                } else {
+                                    me._settings.onMessage(eventMessage);
+                                }
+                                me.instance.data = "";
+                                me.instance.event = "";
+                                countBreakLine = 0;
+                            }
+                            break;
+
+                        // Define the new retry object;
+                        case "retry":
+                            countBreakLine = 0;
+                            me.instance.retry = parseInt(item[1].trim());
+                            break;
+
+                        // Define the new ID
+                        case "id":
+                            countBreakLine = 0;
+                            me.instance.id = item[1].trim();
+                            break;
+
+                        // Define a custom event
+                        case "event":
+                            countBreakLine = 0;
+                            me.instance.event = item[1].trim();
+                            break;
+
+                        // Define the data to be processed.
+                        case "data":
+                            countBreakLine = 0;
+                            me.instance.data += (me.instance.data !== "" ? "\n" : "") + item[1].trim();
+                            break;
+
+                        default:
+                            countBreakLine = 0;
+                    }
+                }
+                setTimeout(function () {
+                    runAjax(me);
+                }, me.instance.retry);
+            },
+            error: me._settings.onError
+        });
+    }
+
+})(jQuery);

--- a/springboot/src/main/resources/static/js/samplessse.js
+++ b/springboot/src/main/resources/static/js/samplessse.js
@@ -1,0 +1,18 @@
+$( document ).ready(function() {
+
+    var sse = $.SSE('/kafka-messages', {
+        onMessage: function(e){
+            console.log(e);
+            $('#kafka-messages tr:last').after('<tr><td>'+e.data+'</td></tr>');
+        },
+        onError: function(e){
+            sse.stop();
+            console.log("Could not connect..Stopping SSE");
+        },
+        onEnd: function(e){
+            console.log("End");
+        }
+    });
+    sse.start();
+
+});

--- a/springboot/src/main/resources/templates/index.html
+++ b/springboot/src/main/resources/templates/index.html
@@ -16,6 +16,9 @@
             <div class="list-group">
                 <a href="/update" class="list-group-item list-group-item-action">Synchronous Update</a>
             </div>
+            <div class="list-group">
+                <a href="/kafka" class="list-group-item list-group-item-action">Kafka Request/Reply</a>
+            </div>
         </div>
     </div>
 </div>

--- a/springboot/src/main/resources/templates/kafka.html
+++ b/springboot/src/main/resources/templates/kafka.html
@@ -1,0 +1,65 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<head th:replace="fragments :: samples-header"></head>
+<body>
+
+<div class="container">
+    <div class="card">
+        <div class="card-body">
+            <h4 class="card-title" th:text="'Temporal Java SDK Samples: ' + ${sample}">Temporal Java SDK Samples</h4>
+            <h6>This sample shows how we can trigger and signal workflow executions by sending messages
+            to Kafka topic. It also shows how workflows can send updates and result to Kafka for other
+            services to consume. <br/>Enter a message in the form and submit. This will trigger a workflow
+            and the messages it sends to Kafka are shown on the page dynamically.</h6>
+            <br/><br/><br/>
+            <div class="form-group">
+                <form action="/kafka", id="sampleform">
+                    <p>Message: <input type="text" name="message"/></p>
+                    <p><input type="submit" value="Send Message" class="btn btn-primary" />
+                </form>
+            </div>
+        </div>
+    </div>
+    <div class="row" >
+        <div class="col-md-6">
+            <div class="panel panel-default" th:fragment="MessageList" id="MessageData">
+                <div class="panel-body">
+                    <div class="table-responsive">
+                        <table class="table table-striped" id="kafka-messages">
+                            <thead>
+                            <tr>
+                                <th>Kafka Messages:</th>
+                            </tr>
+                            </thead>
+                        </table>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+<script type="text/javascript" src="/js/jquery.sse.js"></script>
+<script type="text/javascript" src="/js/samplessse.js"></script>
+<script>
+    $("#sampleform").submit(function( event ) {
+        event.preventDefault();
+
+        var $form = $( this ),
+            message = $form.find( "input[name='message']" ).val(),
+            url = $form.attr( "action" );
+
+        $.ajax({
+            'url': url,
+            'method':'POST',
+            'dataType': 'text',
+            'contentType': 'text/plain',
+            'data': message,
+            success: function(response) {
+                // omit, message sent from activities to kafka topic will update
+            }
+        });
+    });
+</script>
+<footer th:replace="fragments :: samples-footer"></footer>
+</body>
+</html>

--- a/springboot/src/test/java/io/temporal/samples/springboot/HelloSampleTest.java
+++ b/springboot/src/test/java/io/temporal/samples/springboot/HelloSampleTest.java
@@ -38,9 +38,10 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.util.Assert;
 
 @SpringBootTest(classes = HelloSampleTest.Configuration.class)
-@EnableAutoConfiguration(exclude = {KafkaAutoConfiguration.class})
 @ActiveProfiles("test")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+// set this to omit setting up embedded kafka
+@EnableAutoConfiguration(exclude = {KafkaAutoConfiguration.class})
 @DirtiesContext
 public class HelloSampleTest {
 

--- a/springboot/src/test/java/io/temporal/samples/springboot/KafkaConsumerTestHelper.java
+++ b/springboot/src/test/java/io/temporal/samples/springboot/KafkaConsumerTestHelper.java
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (c) 2020 Temporal Technologies, Inc. All Rights Reserved
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.samples.springboot;
+
+import java.util.concurrent.CountDownLatch;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class KafkaConsumerTestHelper {
+  private CountDownLatch latch = new CountDownLatch(5);
+  private String payload = null;
+
+  @KafkaListener(id = "samples-test-id", topics = "${samples.message.topic.name}")
+  public void receive(ConsumerRecord<?, ?> consumerRecord) {
+
+    setPayload(consumerRecord.toString());
+    latch.countDown();
+  }
+
+  public CountDownLatch getLatch() {
+    return latch;
+  }
+
+  public String getPayload() {
+    return payload;
+  }
+
+  private void setPayload(String payload) {
+    this.payload = payload;
+  }
+}

--- a/springboot/src/test/java/io/temporal/samples/springboot/KafkaSampleTest.java
+++ b/springboot/src/test/java/io/temporal/samples/springboot/KafkaSampleTest.java
@@ -50,7 +50,7 @@ public class KafkaSampleTest {
 
   @Autowired WorkflowClient workflowClient;
 
-  @Autowired private KafkaConsumerTestHelper consumer;
+  @Autowired KafkaConsumerTestHelper consumer;
 
   @BeforeEach
   void setUp() {

--- a/springboot/src/test/java/io/temporal/samples/springboot/KafkaSampleTest.java
+++ b/springboot/src/test/java/io/temporal/samples/springboot/KafkaSampleTest.java
@@ -21,28 +21,28 @@ package io.temporal.samples.springboot;
 
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowOptions;
-import io.temporal.samples.springboot.hello.HelloWorkflow;
-import io.temporal.samples.springboot.hello.model.Person;
+import io.temporal.client.WorkflowStub;
+import io.temporal.samples.springboot.kafka.MessageWorkflow;
 import io.temporal.testing.TestWorkflowEnvironment;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.kafka.test.context.EmbeddedKafka;
 import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.util.Assert;
 
-@SpringBootTest(classes = HelloSampleTest.Configuration.class)
-@EnableAutoConfiguration(exclude = {KafkaAutoConfiguration.class})
-@ActiveProfiles("test")
+@SpringBootTest(classes = KafkaSampleTest.Configuration.class)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@EmbeddedKafka(
+    partitions = 1,
+    bootstrapServersProperty = "spring.kafka.bootstrap-servers",
+    controlledShutdown = true)
 @DirtiesContext
-public class HelloSampleTest {
+public class KafkaSampleTest {
 
   @Autowired ConfigurableApplicationContext applicationContext;
 
@@ -50,23 +50,32 @@ public class HelloSampleTest {
 
   @Autowired WorkflowClient workflowClient;
 
+  @Autowired private KafkaConsumerTestHelper consumer;
+
   @BeforeEach
   void setUp() {
     applicationContext.start();
   }
 
   @Test
-  public void testHello() {
-    HelloWorkflow workflow =
+  public void testKafkaWorflow() throws Exception {
+    MessageWorkflow workflow =
         workflowClient.newWorkflowStub(
-            HelloWorkflow.class,
+            MessageWorkflow.class,
             WorkflowOptions.newBuilder()
-                .setTaskQueue("HelloSampleTaskQueue")
-                .setWorkflowId("HelloSampleTest")
+                .setTaskQueue("KafkaSampleTaskQueue")
+                .setWorkflowId("NewMessageWorkflow")
                 .build());
-    String result = workflow.sayHello(new Person("Temporal", "User"));
-    Assert.notNull(result, "Greeting should not be null");
-    Assert.isTrue(result.equals("Hello Temporal User!"), "Invalid result");
+
+    WorkflowClient.start(workflow::start);
+    workflow.update("This is a test message");
+    WorkflowStub.fromTyped(workflow).getResult(Void.class);
+    consumer.getLatch().await();
+
+    Assert.isTrue(consumer.getLatch().getCount() == 0L, "Invalid latch count");
+    Assert.isTrue(
+        consumer.getPayload().contains("Completing execution: NewMessageWorkflow"),
+        "Invalid last event payload");
   }
 
   @ComponentScan

--- a/springboot/src/test/java/io/temporal/samples/springboot/UpdateSampleTest.java
+++ b/springboot/src/test/java/io/temporal/samples/springboot/UpdateSampleTest.java
@@ -29,13 +29,20 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest(classes = HelloUpdateTest.Configuration.class)
+@SpringBootTest(classes = UpdateSampleTest.Configuration.class)
+@EnableAutoConfiguration(exclude = {KafkaAutoConfiguration.class})
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
-public class HelloUpdateTest {
+@ActiveProfiles("test")
+@DirtiesContext
+public class UpdateSampleTest {
 
   @Autowired ConfigurableApplicationContext applicationContext;
 

--- a/springboot/src/test/java/io/temporal/samples/springboot/UpdateSampleTest.java
+++ b/springboot/src/test/java/io/temporal/samples/springboot/UpdateSampleTest.java
@@ -37,10 +37,11 @@ import org.springframework.context.annotation.ComponentScan;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest(classes = UpdateSampleTest.Configuration.class)
-@EnableAutoConfiguration(exclude = {KafkaAutoConfiguration.class})
-@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@SpringBootTest(classes = HelloSampleTest.Configuration.class)
 @ActiveProfiles("test")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+// set this to omit setting up embedded kafka
+@EnableAutoConfiguration(exclude = {KafkaAutoConfiguration.class})
 @DirtiesContext
 public class UpdateSampleTest {
 

--- a/springboot/src/test/resources/application.yaml
+++ b/springboot/src/test/resources/application.yaml
@@ -1,6 +1,8 @@
 server:
   port: 3030
 spring:
+  main:
+    allow-bean-definition-overriding: true
   application:
     name: temporal-samples
   # temporal specific configs
@@ -24,7 +26,17 @@ spring:
     hibernate:
       ddl-auto: create-drop
     defer-datasource-initialization: true
+  ## kafka setup for samples
+  kafka:
+    consumer:
+      auto-offset-reset: earliest
+    bootstrap-servers: ${spring.embedded.kafka.brokers}
 # specific for samples
 samples:
   data:
     language: english
+  message:
+    topic:
+      name: samples-test-topic
+    group:
+      name: samples-group


### PR DESCRIPTION
This sample shows use case where you have existing systems in place that deal with a different queueing tech like Kafka.
In this case you might want to start wf exec when a message is placed on kafka topic and have the kafka consumer trigger
workflow execution. The workflow during its execution can send messages to kafka which can be consumed by some other pretend-existing systems.

It use embedded kafka so users don't have to download and manually start zookeper and kafka. 

For the sample html page user enters a message into form, submitting form sends event to kafka topic.
Kafka consumer then starts wf execution. Activities publish messages to kafka topic.
These messages are then pushed to ui via server side events and are dynamically presented on page.

<img width="1125" alt="Screen Shot 2023-06-29 at 2 13 10 PM" src="https://github.com/temporalio/samples-java/assets/119422/21f7971d-d875-42cf-b97e-b69e5df1a6e7">
