### PR TITLE
update to SpringBoot 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Temporal using the [Java SDK](https://github.com/temporalio/sdk-java).
 
 It contains two modules:
 * [Core](/core): showcases many different SDK features.
-* [SpringBoot](/springboot): showcases springboot autoconfig integration.
+* [SpringBoot](/springboot): showcases SpringBoot autoconfig integration.
 
 ## Learn more about Temporal and Java SDK
 
@@ -15,8 +15,8 @@ It contains two modules:
 
 ## Requirements
 
-- Java 1.8+ for build and runtime
-- Java 11+ for development and contribution
+- Java 1.8+ for build and runtime of core samples
+- Java 1.17+ for build and runtime of Spring Boot samples
 - Local Temporal Server, easiest to get started would be using [Temporal CLI](https://github.com/temporalio/cli).
 For more options see docs [here](https://docs.temporal.io/kb/all-the-ways-to-run-a-cluster).
 
@@ -132,6 +132,8 @@ See the README.md file in each main sample directory for cut/paste Gradle comman
 <!-- @@@SNIPEND -->
 
 ### Running SpringBoot Samples
+
+These samples use SpringBoot 3
 
 1. Start SpringBoot from main repo dir:
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ It contains two modules:
 ## Requirements
 
 - Java 1.8+ for build and runtime of core samples
-- Java 1.17+ for build and runtime of Spring Boot samples
+- Java 1.8+ for build and runtime of SpringBoot samples when using SpringBoot 2
+- Java 1.17+ for build and runtime of Spring Boot samples when using SpringBoot 3
 - Local Temporal Server, easiest to get started would be using [Temporal CLI](https://github.com/temporalio/cli).
 For more options see docs [here](https://docs.temporal.io/kb/all-the-ways-to-run-a-cluster).
 
@@ -133,7 +134,8 @@ See the README.md file in each main sample directory for cut/paste Gradle comman
 
 ### Running SpringBoot Samples
 
-These samples use SpringBoot 3
+These samples use SpringBoot 2 by default. To switch to using SpringBoot 3 look at the [gradle.properties](gradle.properties) file
+and follow simple instructions there.
 
 1. Start SpringBoot from main repo dir:
 

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'org.cadixdev.licenser' version '0.6.1'
     id "net.ltgt.errorprone" version "3.1.0"
     id 'com.diffplug.spotless' version '6.22.0' apply false
-    id 'org.springframework.boot' version '2.7.13'
+    id 'org.springframework.boot' version '3.2.0'
 }
 
 subprojects {
@@ -10,11 +10,6 @@ subprojects {
     apply plugin: 'org.cadixdev.licenser'
     apply plugin: 'net.ltgt.errorprone'
     apply plugin: 'com.diffplug.spotless'
-
-    java {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
 
     compileJava {
         options.compilerArgs << "-Werror"
@@ -47,20 +42,17 @@ subprojects {
         exclude '**/*.js'
     }
 
-    if (JavaVersion.current().isJava11Compatible()) {
-        // Code should be formatted using the latest googleJavaFormat, but it doesn't support Java <11 since version 1.8
-        apply plugin: 'com.diffplug.spotless'
+    apply plugin: 'com.diffplug.spotless'
 
-        spotless {
-            java {
-                target 'src/*/java/**/*.java'
-                targetExclude '**/.idea/**'
-                googleJavaFormat('1.16.0')
-            }
+    spotless {
+        java {
+            target 'src/*/java/**/*.java'
+            targetExclude '**/.idea/**'
+            googleJavaFormat('1.16.0')
         }
-
-        compileJava.dependsOn 'spotlessApply'
     }
+
+    compileJava.dependsOn 'spotlessApply'
 
     test {
         useJUnitPlatform()

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id 'org.cadixdev.licenser' version '0.6.1'
     id "net.ltgt.errorprone" version "3.1.0"
     id 'com.diffplug.spotless' version '6.22.0' apply false
-    id 'org.springframework.boot' version '3.2.0'
+    id "org.springframework.boot" version "${springBootPluginVersion}"
 }
 
 subprojects {
@@ -13,6 +13,16 @@ subprojects {
 
     compileJava {
         options.compilerArgs << "-Werror"
+    }
+
+    java {
+        if(project.property("springBootPluginVersion") == "2.7.13") {
+            sourceCompatibility = JavaVersion.VERSION_11
+            targetCompatibility = JavaVersion.VERSION_11
+        } else {
+            sourceCompatibility = JavaVersion.VERSION_17
+            targetCompatibility = JavaVersion.VERSION_17
+        }
     }
 
     ext {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,4 @@
+springBootPluginVersion=2.7.13
+
+# use this for spring boot 3 support
+#springBootPluginVersion=3.2.0

--- a/springboot/build.gradle
+++ b/springboot/build.gradle
@@ -14,11 +14,7 @@ dependencies {
     testImplementation "org.springframework.boot:spring-boot-starter-test"
     dependencies {
         errorproneJavac('com.google.errorprone:javac:9+181-r4173-1')
-        if (JavaVersion.current().isJava11Compatible()) {
-            errorprone('com.google.errorprone:error_prone_core:2.23.0')
-        } else {
-            errorprone('com.google.errorprone:error_prone_core:2.23.0')
-        }
+        errorprone('com.google.errorprone:error_prone_core:2.23.0')
     }
 }
 
@@ -28,4 +24,9 @@ bootJar {
 
 jar {
     enabled = true
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }

--- a/springboot/build.gradle
+++ b/springboot/build.gradle
@@ -25,8 +25,3 @@ bootJar {
 jar {
     enabled = true
 }
-
-java {
-    sourceCompatibility = JavaVersion.VERSION_17
-    targetCompatibility = JavaVersion.VERSION_17
-}


### PR DESCRIPTION
allows support for both springboot 2 and 3 for the samples. springboot 2 is still default but can change to 3 via gradle.properties