### PR TITLE
Custom actuator endpoint sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ More info on each sample:
 - [**Synchronous Update**](/springboot/src/main/java/io/temporal/samples/springboot/update): Learn how to use Synchronous Update feature with this purchase sample
 - [**Kafka Request / Reply**](/springboot/src/main/java/io/temporal/samples/springboot/kafka): Sample showing possible integration with event streaming platforms such as Kafka
 - [**Customize Options**](/springboot/src/main/java/io/temporal/samples/springboot/customize): Sample showing how to customize options such as WorkerOptions, WorkerFactoryOptions, etc (see options config [here](springboot/src/main/java/io/temporal/samples/springboot/customize/TemporalOptionsConfig.java))
+- [**Customize Options**](/springboot/src/main/java/io/temporal/samples/springboot/actuator): Sample showing how to create a custom Actuator endpoint that shows registered Workflow and Activity impls per task queue.
 
 
 #### Temporal Cloud

--- a/springboot/src/main/java/io/temporal/samples/springboot/SamplesController.java
+++ b/springboot/src/main/java/io/temporal/samples/springboot/SamplesController.java
@@ -75,6 +75,12 @@ public class SamplesController {
     return "metrics";
   }
 
+  @GetMapping("/customendpoint")
+  public String customEndpoint(Model model) {
+    model.addAttribute("sample", "Custom Actuator Worker Info Endpoint");
+    return "actuator";
+  }
+
   @GetMapping("/update")
   public String update(Model model) {
     model.addAttribute("sample", "Synchronous Update");

--- a/springboot/src/main/java/io/temporal/samples/springboot/actuator/README.md
+++ b/springboot/src/main/java/io/temporal/samples/springboot/actuator/README.md
@@ -1,0 +1,13 @@
+# SpringBoot Actuator Worker Info Endpoint - Sample
+
+1. Start SpringBoot from main samples repo directory:
+   
+       ./gradlew bootRun
+
+2. In your browser navigate to:
+ 
+       http://localhost:3030/actuator/temporalworkerinfo
+
+This sample shows how to create a custom Actuator Endpoint that 
+displays registered workflow and activity implementations per task queue.
+This information comes from actually registered workers done by autoconfig module.

--- a/springboot/src/main/java/io/temporal/samples/springboot/actuator/WorkerActuatorEndpoint.java
+++ b/springboot/src/main/java/io/temporal/samples/springboot/actuator/WorkerActuatorEndpoint.java
@@ -1,0 +1,61 @@
+/*
+ *  Copyright (c) 2020 Temporal Technologies, Inc. All Rights Reserved
+ *
+ *  Copyright 2012-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Modifications copyright (C) 2017 Uber Technologies, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ *  use this file except in compliance with the License. A copy of the License is
+ *  located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed on
+ *  an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
+package io.temporal.samples.springboot.actuator;
+
+import io.temporal.spring.boot.autoconfigure.template.WorkersTemplate;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+import org.springframework.stereotype.Component;
+
+@Component
+@Endpoint(id = "temporalworkerinfo")
+public class WorkerActuatorEndpoint {
+  @Autowired
+  @Qualifier("temporalWorkersTemplate")
+  private WorkersTemplate workersTemplate;
+
+  private AtomicInteger counter = new AtomicInteger(0);
+
+  @ReadOperation
+  public String workerInfo() {
+    StringBuilder sb = new StringBuilder();
+    Map<String, WorkersTemplate.RegisteredInfo> registeredInfo =
+        workersTemplate.getRegisteredInfo();
+    sb.append("Worker Info:\n\n");
+    registeredInfo.forEach(
+        (taskQueue, info) ->
+            sb.append(counter.incrementAndGet())
+                .append(".")
+                .append("\tTask Queue: ")
+                .append(taskQueue)
+                .append("\n\tRegistered Workflow Impls: ")
+                .append(info.getRegisteredWorkflowInfo().stream().collect(Collectors.joining(",")))
+                .append("\n\tRegistered Activity Impls: ")
+                .append(info.getRegisteredActivityInfo().stream().collect(Collectors.joining(",")))
+                .append("\n\n"));
+
+    return sb.toString();
+  }
+}

--- a/springboot/src/main/java/io/temporal/samples/springboot/actuator/WorkerActuatorEndpoint.java
+++ b/springboot/src/main/java/io/temporal/samples/springboot/actuator/WorkerActuatorEndpoint.java
@@ -19,9 +19,10 @@
 
 package io.temporal.samples.springboot.actuator;
 
+import io.temporal.common.metadata.*;
 import io.temporal.spring.boot.autoconfigure.template.WorkersTemplate;
+import java.lang.reflect.Method;
 import java.util.Map;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -36,25 +37,70 @@ public class WorkerActuatorEndpoint {
   @Qualifier("temporalWorkersTemplate")
   private WorkersTemplate workersTemplate;
 
-  private AtomicInteger counter = new AtomicInteger(0);
-
   @ReadOperation
   public String workerInfo() {
     StringBuilder sb = new StringBuilder();
     Map<String, WorkersTemplate.RegisteredInfo> registeredInfo =
         workersTemplate.getRegisteredInfo();
-    sb.append("Worker Info:\n\n");
+    sb.append("Worker Info:");
     registeredInfo.forEach(
-        (taskQueue, info) ->
-            sb.append(counter.incrementAndGet())
-                .append(".")
-                .append("\tTask Queue: ")
-                .append(taskQueue)
-                .append("\n\tRegistered Workflow Impls: ")
-                .append(info.getRegisteredWorkflowInfo().stream().collect(Collectors.joining(",")))
-                .append("\n\tRegistered Activity Impls: ")
-                .append(info.getRegisteredActivityInfo().stream().collect(Collectors.joining(",")))
-                .append("\n\n"));
+        (taskQueue, info) -> {
+          sb.append("\n\n\tTask Queue: ").append(taskQueue);
+          info.getRegisteredWorkflowInfo()
+              .forEach(
+                  (workflowInfo) -> {
+                    sb.append("\n\t\t Workflow Interface: ").append(workflowInfo.getClassName());
+                    POJOWorkflowImplMetadata metadata = workflowInfo.getMetadata();
+                    sb.append("\n\t\t\t Workflow Methods: ");
+                    sb.append(
+                        metadata.getWorkflowMethods().stream()
+                            .map(POJOWorkflowMethodMetadata::getWorkflowMethod)
+                            .map(Method::getName)
+                            .collect(Collectors.joining(", ")));
+                    sb.append("\n\t\t\t Query Methods: ");
+                    sb.append(
+                        metadata.getQueryMethods().stream()
+                            .map(POJOWorkflowMethodMetadata::getWorkflowMethod)
+                            .map(Method::getName)
+                            .collect(Collectors.joining(", ")));
+                    sb.append("\n\t\t\t Signal Methods: ");
+                    sb.append(
+                        metadata.getSignalMethods().stream()
+                            .map(POJOWorkflowMethodMetadata::getWorkflowMethod)
+                            .map(Method::getName)
+                            .collect(Collectors.joining(", ")));
+                    sb.append("\n\t\t\t Update Methods: ");
+                    sb.append(
+                        metadata.getUpdateMethods().stream()
+                            .map(POJOWorkflowMethodMetadata::getWorkflowMethod)
+                            .map(Method::getName)
+                            .collect(Collectors.joining(",")));
+                    sb.append("\n\t\t\t Update Validator Methods: ");
+                    sb.append(
+                        metadata.getUpdateValidatorMethods().stream()
+                            .map(POJOWorkflowMethodMetadata::getWorkflowMethod)
+                            .map(Method::getName)
+                            .collect(Collectors.joining(", ")));
+                  });
+          info.getRegisteredActivityInfo()
+              .forEach(
+                  (activityInfo) -> {
+                    sb.append("\n\t\t Activity Impl: ").append(activityInfo.getClassName());
+                    POJOActivityImplMetadata metadata = activityInfo.getMetadata();
+                    sb.append("\n\t\t\t Activity Interfaces: ");
+                    sb.append(
+                        metadata.getActivityInterfaces().stream()
+                            .map(POJOActivityInterfaceMetadata::getInterfaceClass)
+                            .map(Class::getName)
+                            .collect(Collectors.joining(",")));
+                    sb.append("\n\t\t\t Activity Methods: ");
+                    sb.append(
+                        metadata.getActivityMethods().stream()
+                            .map(POJOActivityMethodMetadata::getMethod)
+                            .map(Method::getName)
+                            .collect(Collectors.joining(", ")));
+                  });
+        });
 
     return sb.toString();
   }

--- a/springboot/src/main/resources/application.yaml
+++ b/springboot/src/main/resources/application.yaml
@@ -49,7 +49,7 @@ management:
   endpoints:
     web:
       exposure:
-        include: prometheus
+        include: prometheus,temporalworkerinfo
 # specific for samples
 samples:
   data:

--- a/springboot/src/main/resources/templates/actuator.html
+++ b/springboot/src/main/resources/templates/actuator.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns="http://www.w3.org/1999/html">
+<head th:replace="fragments :: samples-header"></head>
+<body>
+<div class="container">
+    <div class="card">
+        <div class="card-body">
+            <h4 class="card-title" th:text="'Temporal Java SDK Samples: ' + ${sample}">Temporal Java SDK Samples</h4>
+            <h6>In this sample we show how to create a custom Actuator Endpoint showing Worker Info.</h6>
+            <br/><br/>
+            <div>
+                <h6><a href="https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html" target="_blank">Spring Actuator</a> allows
+                us to create custom endpoints. This sample shows how to create a Worker Info custom endpoint that shows registered Workflow and Activity impls per task queue.</h6><br/>
+                View the custom endpoint at <a href="http://localhost:3030/actuator/temporalworkerinfo" target="_blank">localhost:3030/actuator/temporalworkerinfo</a>
+            </div>
+    </div>
+</div>
+<footer th:replace="fragments :: samples-footer"></footer>
+</body>
+</html>

--- a/springboot/src/main/resources/templates/index.html
+++ b/springboot/src/main/resources/templates/index.html
@@ -22,6 +22,9 @@
             <div class="list-group">
                 <a href="/customize" class="list-group-item list-group-item-action">Customize Options</a>
             </div>
+            <div class="list-group">
+                <a href="/customendpoint" class="list-group-item list-group-item-action">Custom Actuator Endpoint - Worker Info</a>
+            </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
This sample shows how to add a custom actuator endpoint to display some info on workers like workflow and activity impls registered per task queue. Sample depends on sdk pr https://github.com/temporalio/sdk-java/pull/1986
and https://github.com/temporalio/sdk-java/pull/1995

and update to next sdk release (one that has these prs in it)

Custom endpoint looks like this

Updated to add metadata --

<img width="919" alt="Screenshot 2024-02-25 at 9 40 45 PM" src="https://github.com/temporalio/samples-java/assets/119422/07032aae-4a3a-4840-b4c8-cd370e901d7b">

