### PR TITLE
Tidy up service description

### DIFF
--- a/core/src/main/java/io/temporal/samples/nexus/service/description.md
+++ b/core/src/main/java/io/temporal/samples/nexus/service/description.md
@@ -1,8 +1,6 @@
-Service Name:
-NexusService
-Operation Names:
-echo
-hello
+## Service: [NexusService](https://github.com/temporalio/samples-java/blob/main/core/src/main/java/io/temporal/samples/nexus/service/NexusService.java)
+ - operation: `echo`
+ - operation: `hello`
 
-Input / Output arguments are in the following repository:
-https://github.com/temporalio/samples-java/core/src/main/java/io/temporal/samples/nexus/service/NexusService.java
+See https://github.com/temporalio/samples-java/blob/main/core/src/main/java/io/temporal/samples/nexus/service/NexusService.java for Input / Output types.
+


### PR DESCRIPTION
Convert the service description to markdown.

This is just a quick fix: we could make this more elaborate in subsequent PRs.

Rendered: https://github.com/temporalio/samples-java/blob/fix-nexus-descriptions/core/src/main/java/io/temporal/samples/nexus/service/description.md