### PR TITLE
due to -Werror compiler arg, build is failing on warning

### DIFF
--- a/core/src/main/java/io/temporal/samples/workerversioning/Starter.java
+++ b/core/src/main/java/io/temporal/samples/workerversioning/Starter.java
@@ -146,6 +146,7 @@ public class Starter {
           break;
         }
       } catch (Exception ignored) {
+        // Exception intentionally ignored
       }
       Thread.sleep(1000);
     }


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
Added a comment to an ignored catch block in Starter.java. Builds fail as there is a defined compiler arg: -Werror
```
    compileJava {
        options.compilerArgs << "-Werror"
    }
```
## Why?
So we can build

2. How was this tested:
built and tested
