### PR TITLE
Inline Nexus workflow ID formatting

### DIFF
--- a/core/src/main/java/io/temporal/samples/nexus/handler/SampleNexusServiceImpl.java
+++ b/core/src/main/java/io/temporal/samples/nexus/handler/SampleNexusServiceImpl.java
@@ -58,8 +58,7 @@ public class SampleNexusServiceImpl {
                         // Workflow IDs should typically be business meaningful IDs and are used to
                         // dedupe workflow starts.
                         // For this example, tie the workflow ID to the customer being greeted so
-                        // that
-                        // repeated operations for the same customer run on the same workflow.
+                        // that repeated operations for the same customer run on the same workflow.
                         //
                         // Task queue defaults to the task queue this operation is handled on.
                         WorkflowOptions.newBuilder()

--- a/core/src/main/java/io/temporal/samples/nexus/handler/SampleNexusServiceImpl.java
+++ b/core/src/main/java/io/temporal/samples/nexus/handler/SampleNexusServiceImpl.java
@@ -7,6 +7,7 @@ import io.temporal.client.WorkflowOptions;
 import io.temporal.nexus.Nexus;
 import io.temporal.nexus.WorkflowRunOperation;
 import io.temporal.samples.nexus.service.SampleNexusService;
+import java.util.Locale;
 
 // To create a service implementation, annotate the class with @ServiceImpl and provide the
 // interface that the service implements. The service implementation class should have methods that
@@ -55,13 +56,19 @@ public class SampleNexusServiceImpl {
                     .newWorkflowStub(
                         HelloHandlerWorkflow.class,
                         // Workflow IDs should typically be business meaningful IDs and are used to
-                        // dedupe workflow starts. For this example, we're using the request ID
-                        // allocated by Temporal when the caller workflow schedules
-                        // the operation, this ID is guaranteed to be stable across retries of this
-                        // operation.
+                        // dedupe workflow starts.
+                        // For this example, tie the workflow ID to the customer being greeted so
+                        // that
+                        // repeated operations for the same customer run on the same workflow.
                         //
                         // Task queue defaults to the task queue this operation is handled on.
-                        WorkflowOptions.newBuilder().setWorkflowId(details.getRequestId()).build())
+                        WorkflowOptions.newBuilder()
+                            .setWorkflowId(
+                                String.format(
+                                    "hello-%s-%s",
+                                    input.getName(),
+                                    input.getLanguage().name().toLowerCase(Locale.ROOT)))
+                            .build())
                 ::hello);
   }
 }

--- a/core/src/main/java/io/temporal/samples/nexus/handler/SampleNexusServiceImpl.java
+++ b/core/src/main/java/io/temporal/samples/nexus/handler/SampleNexusServiceImpl.java
@@ -57,6 +57,7 @@ public class SampleNexusServiceImpl {
                         HelloHandlerWorkflow.class,
                         // Workflow IDs should typically be business meaningful IDs and are used to
                         // dedupe workflow starts.
+                        //
                         // For this example, tie the workflow ID to the customer being greeted so
                         // that repeated operations for the same customer run on the same workflow.
                         //

--- a/core/src/main/java/io/temporal/samples/nexuscontextpropagation/handler/SampleNexusServiceImpl.java
+++ b/core/src/main/java/io/temporal/samples/nexuscontextpropagation/handler/SampleNexusServiceImpl.java
@@ -53,9 +53,9 @@ public class SampleNexusServiceImpl {
                         HelloHandlerWorkflow.class,
                         // Workflow IDs should typically be business meaningful IDs and are used to
                         // dedupe workflow starts.
+                        //
                         // For this example, tie the workflow ID to the customer being greeted so
-                        // that
-                        // repeated operations for the same customer run on the same workflow.
+                        // that repeated operations for the same customer run on the same workflow.
                         //
                         // Task queue defaults to the task queue this operation is handled on.
                         WorkflowOptions.newBuilder()

--- a/core/src/main/java/io/temporal/samples/nexuscontextpropagation/handler/SampleNexusServiceImpl.java
+++ b/core/src/main/java/io/temporal/samples/nexuscontextpropagation/handler/SampleNexusServiceImpl.java
@@ -8,6 +8,7 @@ import io.temporal.nexus.Nexus;
 import io.temporal.nexus.WorkflowRunOperation;
 import io.temporal.samples.nexus.handler.HelloHandlerWorkflow;
 import io.temporal.samples.nexus.service.SampleNexusService;
+import java.util.Locale;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -52,14 +53,18 @@ public class SampleNexusServiceImpl {
                         HelloHandlerWorkflow.class,
                         // Workflow IDs should typically be business meaningful IDs and are used to
                         // dedupe workflow starts.
-                        // For this example, we're using the request ID allocated by Temporal when
-                        // the
-                        // caller workflow schedules
-                        // the operation, this ID is guaranteed to be stable across retries of this
-                        // operation.
+                        // For this example, tie the workflow ID to the customer being greeted so
+                        // that
+                        // repeated operations for the same customer run on the same workflow.
                         //
                         // Task queue defaults to the task queue this operation is handled on.
-                        WorkflowOptions.newBuilder().setWorkflowId(details.getRequestId()).build())
+                        WorkflowOptions.newBuilder()
+                            .setWorkflowId(
+                                String.format(
+                                    "hello-%s-%s",
+                                    input.getName(),
+                                    input.getLanguage().name().toLowerCase(Locale.ROOT)))
+                            .build())
                 ::hello);
   }
 }

--- a/core/src/main/java/io/temporal/samples/nexusmultipleargs/handler/SampleNexusServiceImpl.java
+++ b/core/src/main/java/io/temporal/samples/nexusmultipleargs/handler/SampleNexusServiceImpl.java
@@ -43,7 +43,8 @@ public class SampleNexusServiceImpl {
                             // to dedupe workflow starts.
                             //
                             // For this example, tie the workflow ID to the customer being greeted
-                            // so that repeated operations for the same customer run on the same workflow.
+                            // so that repeated operations for the same customer run on the same
+                            // workflow.
                             //
                             // Task queue defaults to the task queue this operation is handled on.
                             WorkflowOptions.newBuilder()

--- a/core/src/main/java/io/temporal/samples/nexusmultipleargs/handler/SampleNexusServiceImpl.java
+++ b/core/src/main/java/io/temporal/samples/nexusmultipleargs/handler/SampleNexusServiceImpl.java
@@ -8,6 +8,7 @@ import io.temporal.nexus.Nexus;
 import io.temporal.nexus.WorkflowHandle;
 import io.temporal.nexus.WorkflowRunOperation;
 import io.temporal.samples.nexus.service.SampleNexusService;
+import java.util.Locale;
 
 // To create a service implementation, annotate the class with @ServiceImpl and provide the
 // interface that the service implements. The service implementation class should have methods that
@@ -41,17 +42,18 @@ public class SampleNexusServiceImpl {
                             // Workflow IDs should typically be business meaningful IDs and are used
                             // to
                             // dedupe workflow starts.
-                            // For this example, we're using the request ID allocated by Temporal
-                            // when
-                            // the
-                            // caller workflow schedules
-                            // the operation, this ID is guaranteed to be stable across retries of
-                            // this
-                            // operation.
+                            // For this example, tie the workflow ID to the customer being greeted
+                            // so
+                            // that
+                            // repeated operations for the same customer run on the same workflow.
                             //
                             // Task queue defaults to the task queue this operation is handled on.
                             WorkflowOptions.newBuilder()
-                                .setWorkflowId(details.getRequestId())
+                                .setWorkflowId(
+                                    String.format(
+                                        "hello-%s-%s",
+                                        input.getName(),
+                                        input.getLanguage().name().toLowerCase(Locale.ROOT)))
                                 .build())
                     ::hello,
                 input.getName(),

--- a/core/src/main/java/io/temporal/samples/nexusmultipleargs/handler/SampleNexusServiceImpl.java
+++ b/core/src/main/java/io/temporal/samples/nexusmultipleargs/handler/SampleNexusServiceImpl.java
@@ -40,12 +40,10 @@ public class SampleNexusServiceImpl {
                         .newWorkflowStub(
                             HelloHandlerWorkflow.class,
                             // Workflow IDs should typically be business meaningful IDs and are used
-                            // to
-                            // dedupe workflow starts.
+                            // to dedupe workflow starts.
+                            //
                             // For this example, tie the workflow ID to the customer being greeted
-                            // so
-                            // that
-                            // repeated operations for the same customer run on the same workflow.
+                            // so that repeated operations for the same customer run on the same workflow.
                             //
                             // Task queue defaults to the task queue this operation is handled on.
                             WorkflowOptions.newBuilder()


### PR DESCRIPTION
Use proper business IDs instead of request IDs in nexus samples, per https://github.com/temporalio/features/issues/692

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6912845292708331ab633436fbe72984)