### PR TITLE
fix: use single-line comments for SNIP markers to avoid NotJavadoc warnings

### DIFF
--- a/core/src/main/java/io/temporal/samples/envconfig/LoadFromFile.java
+++ b/core/src/main/java/io/temporal/samples/envconfig/LoadFromFile.java
@@ -1,8 +1,6 @@
 package io.temporal.samples.envconfig;
 
-/**
- * @@@SNIPSTART java-env-config-profile
- */
+// @@@SNIPSTART java-env-config-profile
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowClientOptions;
 import io.temporal.envconfig.ClientConfigProfile;
@@ -80,6 +78,4 @@ public class LoadFromFile {
     }
   }
 }
-/**
- * @@@SNIPEND
- */
+// @@@SNIPEND

--- a/core/src/main/java/io/temporal/samples/envconfig/LoadProfile.java
+++ b/core/src/main/java/io/temporal/samples/envconfig/LoadProfile.java
@@ -1,8 +1,6 @@
 package io.temporal.samples.envconfig;
 
-/**
- * @@@SNIPSTART java-env-config-profile-with-overrides
- */
+// @@@SNIPSTART java-env-config-profile-with-overrides
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowClientOptions;
 import io.temporal.envconfig.ClientConfigProfile;
@@ -88,6 +86,4 @@ public class LoadProfile {
     }
   }
 }
-/**
- * @@@SNIPEND
- */
+// @@@SNIPEND


### PR DESCRIPTION
## Summary
- Changed SNIP markers from `/**` block comments to `//` single-line comments in envconfig samples
- Fixes ErrorProne's NotJavadoc warnings that were causing build failures with `-Werror`

## Files Changed
- `core/src/main/java/io/temporal/samples/envconfig/LoadFromFile.java`
- `core/src/main/java/io/temporal/samples/envconfig/LoadProfile.java`

## Test plan
- [x] `./gradlew :core:compileJava` passes
- [x] `./gradlew build -x :springboot:test` passes (excluding pre-existing test failure)

Note: `HelloSampleTestMockedActivity` test failure is a pre-existing issue unrelated to this change.