### PR TITLE
Bump project to Java 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,11 +42,14 @@ jobs:
     - name: Set up Java
       uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
       with:
-        java-version: "11"
+        # The springai sample modules require Java 17 (Spring AI 1.1 needs
+        # Spring Boot 3.x, which needs Java 17). google-java-format has to
+        # run on Java 17 to parse those sources.
+        java-version: "17"
         distribution: "temurin"
 
     - name: Set up Gradle
       uses: gradle/actions/setup-gradle@ac396bf1a80af16236baf54bd7330ae21dc6ece5 # v6
-    
+
     - name: Run copyright and code format checks
       run: ./gradlew --no-daemon spotlessCheck

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,9 +42,6 @@ jobs:
     - name: Set up Java
       uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
       with:
-        # The springai sample modules require Java 17 (Spring AI 1.1 needs
-        # Spring Boot 3.x, which needs Java 17). google-java-format has to
-        # run on Java 17 to parse those sources.
         java-version: "17"
         distribution: "temurin"
 

--- a/build.gradle
+++ b/build.gradle
@@ -14,13 +14,8 @@ subprojects {
     }
 
     java {
-        if(project.property("springBootPluginVersion") == "2.7.13") {
-            sourceCompatibility = JavaVersion.VERSION_11
-            targetCompatibility = JavaVersion.VERSION_11
-        } else {
-            sourceCompatibility = JavaVersion.VERSION_17
-            targetCompatibility = JavaVersion.VERSION_17
-        }
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
     }
 
     ext {

--- a/docker/github/Dockerfile
+++ b/docker/github/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:11-focal
+FROM eclipse-temurin:17-jammy
 
 # Git is needed in order to update the dls submodule
 RUN apt-get update && apt-get install -y wget protobuf-compiler git

--- a/springboot-basic/build.gradle
+++ b/springboot-basic/build.gradle
@@ -9,11 +9,7 @@ dependencies {
     runtimeOnly "io.micrometer:micrometer-registry-prometheus"
     dependencies {
         errorproneJavac('com.google.errorprone:javac:9+181-r4173-1')
-        if (JavaVersion.current().isJava11Compatible()) {
-            errorprone('com.google.errorprone:error_prone_core:2.28.0')
-        } else {
-            errorprone('com.google.errorprone:error_prone_core:2.28.0')
-        }
+        errorprone('com.google.errorprone:error_prone_core:2.28.0')
     }
 }
 


### PR DESCRIPTION
## Summary

Spring AI work surfaced that the project's CI and build settings still pinned Java 11 in several places. This PR moves to Java 17 everywhere:

- `docker/github/Dockerfile`: `eclipse-temurin:11-focal` → `:17-jammy` (image used by the unittest CI job)
- root `build.gradle`: drop the Spring-Boot-version-conditional Java target (Spring Boot 2.7 runs on Java 17 fine)
- `springboot-basic/build.gradle`: drop a dead `isJava11Compatible()` branch with identical arms
- `ci.yml`: keep Java 17 on the Code format job (cherry-picked from the in-flight Spring AI samples PR), clean up the inline comment that framed it as a springai-only exception

Split out from #775 so the Java-version bump can be reviewed independently.

## Test plan

- [x] `./gradlew clean spotlessCheck compileJava` passes locally
- [x] CI green on this branch