### PR TITLE
Add toolregistryincidenttriage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ Load client configuration from TOML files with programmatic overrides.
 
 - [**Standalone Activities**](/core/src/main/java/io/temporal/samples/standaloneactivities): Demonstrates how to start, execute, list, and count Standalone Activities — Activities that run independently without a Workflow, using ActivityClient.
 
+- [**Tool Registry: Incident Triage**](/core/src/main/java/io/temporal/samples/toolregistryincidenttriage): LLM-driven incident triage activity using the `temporal-tool-registry` contrib module. Demonstrates `AgenticSession`, MCP HTTP integration, human-in-the-loop via a companion workflow, and a testable activity refactor (`buildTriageRegistry` + `TriageDeps`).
+
 #### SDK Metrics
 
 - [**Set up SDK metrics**](/core/src/main/java/io/temporal/samples/metrics): Demonstrates how to set up and scrape SDK metrics.

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -4,6 +4,11 @@ dependencies {
     implementation "io.temporal:temporal-opentracing:$javaSDKVersion"
     testImplementation("io.temporal:temporal-testing:$javaSDKVersion")
 
+    // Tool Registry (in-development; install via
+    // `JAVA_HOME=$JDK21 ./gradlew :temporal-tool-registry:publishToMavenLocal` from sdk-java first)
+    implementation "io.temporal:temporal-tool-registry:1.35.0-SNAPSHOT"
+    implementation "com.anthropic:anthropic-java:2.24.0"
+
     // Environment configuration
     implementation "io.temporal:temporal-envconfig:$javaSDKVersion"
 

--- a/core/src/main/java/io/temporal/samples/toolregistryincidenttriage/ApprovalWorkflow.java
+++ b/core/src/main/java/io/temporal/samples/toolregistryincidenttriage/ApprovalWorkflow.java
@@ -1,0 +1,28 @@
+package io.temporal.samples.toolregistryincidenttriage;
+
+import io.temporal.workflow.QueryMethod;
+import io.temporal.workflow.SignalMethod;
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
+
+/**
+ * Companion HITL workflow.
+ *
+ * <p>The triage agent's request_human_approval tool calls signalWithStart against a deterministic
+ * ID per alert group. This workflow stores the latest request, exposes it as a query, and returns
+ * the operator's decision.
+ */
+@WorkflowInterface
+public interface ApprovalWorkflow {
+  @WorkflowMethod
+  Types.ApprovalResponse run(String key);
+
+  @SignalMethod(name = "approval-request")
+  void approvalRequest(Types.ApprovalRequest req);
+
+  @SignalMethod(name = "approval-decision")
+  void approvalDecision(Types.ApprovalResponse res);
+
+  @QueryMethod(name = "pending-approval")
+  Types.ApprovalRequest pendingApproval();
+}

--- a/core/src/main/java/io/temporal/samples/toolregistryincidenttriage/ApprovalWorkflowImpl.java
+++ b/core/src/main/java/io/temporal/samples/toolregistryincidenttriage/ApprovalWorkflowImpl.java
@@ -1,0 +1,33 @@
+package io.temporal.samples.toolregistryincidenttriage;
+
+import io.temporal.workflow.Workflow;
+
+public class ApprovalWorkflowImpl implements ApprovalWorkflow {
+  private Types.ApprovalRequest request;
+  private Types.ApprovalResponse response;
+
+  @Override
+  public Types.ApprovalResponse run(String key) {
+    // Wait for the agent's request, then the operator's decision.
+    // LLM retry: re-attached requests overwrite prior state — operator only
+    // ever sees the latest version, since the agent may refine its ask.
+    Workflow.await(() -> request != null);
+    Workflow.await(() -> response != null);
+    return response;
+  }
+
+  @Override
+  public void approvalRequest(Types.ApprovalRequest req) {
+    this.request = req;
+  }
+
+  @Override
+  public void approvalDecision(Types.ApprovalResponse res) {
+    this.response = res;
+  }
+
+  @Override
+  public Types.ApprovalRequest pendingApproval() {
+    return request;
+  }
+}

--- a/core/src/main/java/io/temporal/samples/toolregistryincidenttriage/Client.java
+++ b/core/src/main/java/io/temporal/samples/toolregistryincidenttriage/Client.java
@@ -1,0 +1,124 @@
+package io.temporal.samples.toolregistryincidenttriage;
+
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowClientOptions;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.serviceclient.WorkflowServiceStubs;
+import io.temporal.serviceclient.WorkflowServiceStubsOptions;
+import java.time.Instant;
+import java.util.Map;
+
+/**
+ * CLI: approve / reject / trigger.
+ *
+ * <p>Listing pending approval workflows is left to the Temporal CLI: temporal workflow list --query
+ * 'WorkflowType="ApprovalWorkflow" AND ExecutionStatus="Running"'
+ */
+public class Client {
+  public static void main(String[] args) throws Exception {
+    if (args.length == 0) {
+      System.err.println("Usage: client <approve|reject|trigger> ...");
+      System.exit(1);
+    }
+    WorkflowClient client = makeClient();
+    switch (args[0]) {
+      case "approve":
+        if (args.length < 3) {
+          System.err.println("Usage: client approve <wfid> <reason>");
+          System.exit(1);
+        }
+        decide(client, "approved", args[1], joinFrom(args, 2));
+        break;
+      case "reject":
+        if (args.length < 3) {
+          System.err.println("Usage: client reject <wfid> <reason>");
+          System.exit(1);
+        }
+        decide(client, "rejected", args[1], joinFrom(args, 2));
+        break;
+      case "trigger":
+        if (args.length < 3) {
+          System.err.println("Usage: client trigger <alertname> <service>");
+          System.exit(1);
+        }
+        trigger(client, args[1], args[2]);
+        break;
+      default:
+        System.err.println("Unknown command: " + args[0]);
+        System.exit(1);
+    }
+  }
+
+  static WorkflowClient makeClient() {
+    String address = mustEnv("TEMPORAL_ADDRESS");
+    String namespace = mustEnv("TEMPORAL_NAMESPACE");
+    String apiKey = mustEnv("TEMPORAL_API_KEY");
+    WorkflowServiceStubs s =
+        WorkflowServiceStubs.newServiceStubs(
+            WorkflowServiceStubsOptions.newBuilder()
+                .setTarget(address)
+                .addApiKey(() -> apiKey)
+                .build());
+    return WorkflowClient.newInstance(
+        s, WorkflowClientOptions.newBuilder().setNamespace(namespace).build());
+  }
+
+  static void decide(WorkflowClient client, String decision, String workflowId, String reason) {
+    ApprovalWorkflow stub = client.newWorkflowStub(ApprovalWorkflow.class, workflowId);
+    Types.ApprovalResponse r = new Types.ApprovalResponse(decision, reason);
+    stub.approvalDecision(r);
+    System.out.println("signaled " + workflowId + ": " + decision + " — " + reason);
+  }
+
+  static void trigger(WorkflowClient client, String alertname, String service) {
+    String taskQueue = System.getenv().getOrDefault("TEMPORAL_TASK_QUEUE", "triage-java");
+    String wfId =
+        "triage-"
+            + alertname.toLowerCase(java.util.Locale.ROOT)
+            + "-"
+            + service.toLowerCase(java.util.Locale.ROOT);
+    Types.AlertPayload alert = new Types.AlertPayload();
+    alert.status = "firing";
+    alert.labels =
+        Map.of(
+            "alertname",
+            alertname,
+            "service",
+            service,
+            "severity",
+            "critical",
+            "runbook",
+            "synthetic");
+    alert.annotations =
+        Map.of(
+            "summary",
+            "Synthetic test alert for " + service,
+            "description",
+            "Triggered manually via Client to exercise the triage flow.");
+    alert.startsAt = Instant.now().toString();
+    IncidentTriageWorkflow stub =
+        client.newWorkflowStub(
+            IncidentTriageWorkflow.class,
+            WorkflowOptions.newBuilder().setWorkflowId(wfId).setTaskQueue(taskQueue).build());
+    WorkflowClient.start(stub::run, alert);
+    System.out.println("started triage workflow: " + wfId + " on " + taskQueue);
+  }
+
+  static String mustEnv(String name) {
+    String v = System.getenv(name);
+    if (v == null || v.isEmpty()) {
+      System.err.println("missing env var: " + name);
+      System.exit(1);
+    }
+    return v;
+  }
+
+  static String joinFrom(String[] arr, int from) {
+    StringBuilder b = new StringBuilder();
+    for (int i = from; i < arr.length; i++) {
+      if (i > from) b.append(' ');
+      b.append(arr[i]);
+    }
+    return b.toString();
+  }
+}

--- a/core/src/main/java/io/temporal/samples/toolregistryincidenttriage/IncidentTriageWorkflow.java
+++ b/core/src/main/java/io/temporal/samples/toolregistryincidenttriage/IncidentTriageWorkflow.java
@@ -1,0 +1,21 @@
+package io.temporal.samples.toolregistryincidenttriage;
+
+import io.temporal.workflow.QueryMethod;
+import io.temporal.workflow.SignalMethod;
+import io.temporal.workflow.WorkflowInterface;
+import io.temporal.workflow.WorkflowMethod;
+
+@WorkflowInterface
+public interface IncidentTriageWorkflow {
+  @WorkflowMethod
+  Types.TriageResult run(Types.AlertPayload alert);
+
+  @SignalMethod(name = "alert-update")
+  void alertUpdate(Types.AlertPayload alert);
+
+  @QueryMethod(name = "current-alert")
+  Types.AlertPayload currentAlert();
+
+  @QueryMethod(name = "triage-result")
+  Types.TriageResult triageResult();
+}

--- a/core/src/main/java/io/temporal/samples/toolregistryincidenttriage/IncidentTriageWorkflowImpl.java
+++ b/core/src/main/java/io/temporal/samples/toolregistryincidenttriage/IncidentTriageWorkflowImpl.java
@@ -1,0 +1,40 @@
+package io.temporal.samples.toolregistryincidenttriage;
+
+import io.temporal.activity.ActivityOptions;
+import io.temporal.workflow.Workflow;
+import java.time.Duration;
+
+public class IncidentTriageWorkflowImpl implements IncidentTriageWorkflow {
+  private Types.AlertPayload currentAlert;
+  private Types.TriageResult result;
+
+  @Override
+  public Types.TriageResult run(Types.AlertPayload alert) {
+    this.currentAlert = alert;
+    // agenticHitl-shaped timeouts (matches lexicon-temporal's profile).
+    ActivityOptions opts =
+        ActivityOptions.newBuilder()
+            .setStartToCloseTimeout(Duration.ofHours(8))
+            .setHeartbeatTimeout(Duration.ofMinutes(2))
+            // 1 attempt — AgenticSession heartbeat is the resume mechanism.
+            .build();
+    TriageActivity activity = Workflow.newActivityStub(TriageActivity.class, opts);
+    this.result = activity.triageIncident(currentAlert);
+    return this.result;
+  }
+
+  @Override
+  public void alertUpdate(Types.AlertPayload alert) {
+    this.currentAlert = alert;
+  }
+
+  @Override
+  public Types.AlertPayload currentAlert() {
+    return currentAlert;
+  }
+
+  @Override
+  public Types.TriageResult triageResult() {
+    return result;
+  }
+}

--- a/core/src/main/java/io/temporal/samples/toolregistryincidenttriage/TriageActivity.java
+++ b/core/src/main/java/io/temporal/samples/toolregistryincidenttriage/TriageActivity.java
@@ -1,0 +1,10 @@
+package io.temporal.samples.toolregistryincidenttriage;
+
+import io.temporal.activity.ActivityInterface;
+import io.temporal.activity.ActivityMethod;
+
+@ActivityInterface
+public interface TriageActivity {
+  @ActivityMethod(name = "triage_incident_activity")
+  Types.TriageResult triageIncident(Types.AlertPayload alert);
+}

--- a/core/src/main/java/io/temporal/samples/toolregistryincidenttriage/TriageActivityImpl.java
+++ b/core/src/main/java/io/temporal/samples/toolregistryincidenttriage/TriageActivityImpl.java
@@ -1,6 +1,7 @@
 package io.temporal.samples.toolregistryincidenttriage;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.temporal.activity.Activity;
 import io.temporal.api.enums.v1.WorkflowIdConflictPolicy;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowOptions;
@@ -438,7 +439,24 @@ public class TriageActivityImpl implements TriageActivity {
     // workflow registers its handler.
     WorkflowStub.fromTyped(stub)
         .signalWithStart("approval-request", new Object[] {req}, new Object[] {key});
-    return stub.run(key); // already running; this returns the in-flight result
+
+    // Heartbeat every 30 seconds while waiting on the approval workflow.
+    // AgenticSession only heartbeats between LLM turns, so a multi-hour
+    // operator wait inside this handler would otherwise trigger heartbeat
+    // timeout in 120s and kill the activity.
+    java.util.concurrent.ScheduledExecutorService ticker =
+        java.util.concurrent.Executors.newSingleThreadScheduledExecutor();
+    var unused =
+        ticker.scheduleAtFixedRate(
+            () -> Activity.getExecutionContext().heartbeat(null),
+            30,
+            30,
+            java.util.concurrent.TimeUnit.SECONDS);
+    try {
+      return stub.run(key); // already running; this returns the in-flight result
+    } finally {
+      ticker.shutdownNow();
+    }
   }
 
   static String envOr(String n, String d) {

--- a/core/src/main/java/io/temporal/samples/toolregistryincidenttriage/TriageActivityImpl.java
+++ b/core/src/main/java/io/temporal/samples/toolregistryincidenttriage/TriageActivityImpl.java
@@ -1,0 +1,450 @@
+package io.temporal.samples.toolregistryincidenttriage;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowOptions;
+import io.temporal.serviceclient.WorkflowServiceStubs;
+import io.temporal.serviceclient.WorkflowServiceStubsOptions;
+import io.temporal.toolregistry.AgenticSession;
+import io.temporal.toolregistry.AnthropicConfig;
+import io.temporal.toolregistry.AnthropicProvider;
+import io.temporal.toolregistry.ToolDefinition;
+import io.temporal.toolregistry.ToolHandler;
+import io.temporal.toolregistry.ToolRegistry;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Java port of the triage activity. Mirrors workers/typescript and workers/python.
+ *
+ * <p>Structure: {@link #buildTriageRegistry(Types.AlertPayload, AgenticSession, TriageDeps)} is the
+ * testable seam — pure modulo deps. {@link #triageIncident(Types.AlertPayload)} composes
+ * runWithSession + the registry + the Anthropic provider.
+ */
+public class TriageActivityImpl implements TriageActivity {
+
+  public static final String SYSTEM_PROMPT =
+      "You are an SRE on-call agent triaging a production alert.\n\n"
+          + "You have these tools (sourced from MCP sidecars + per-language helpers):\n"
+          + "  - prometheus_query(query)            instant PromQL query\n"
+          + "  - prometheus_query_range(query, start, end, step)\n"
+          + "  - prometheus_alerts()                what is currently firing\n"
+          + "  - kubectl_get(resource, namespace?)  list K8s resources\n"
+          + "  - kubectl_describe(resource, name, namespace?)\n"
+          + "  - kubectl_logs(pod, namespace, tail?)\n"
+          + "  - propose_remediation(action, justification)   record but do NOT execute\n"
+          + "  - request_human_approval(message, diagnosis, proposedAction)\n"
+          + "                                       blocks until operator says approve|reject\n"
+          + "  - execute_remediation(action)        ONLY callable AFTER approval was approved.\n"
+          + "                                       Pass the same action you got approved.\n"
+          + "  - report_resolved(summary)           ends the loop with status=resolved\n"
+          + "  - report_unresolved(summary)         ends the loop with status=unresolved\n\n"
+          + "Workflow:\n"
+          + "  1. Read the alert. Use prometheus_query to confirm the symptom is currently true.\n"
+          + "  2. Use kubectl_get/describe/logs and prometheus_query_range to find root cause.\n"
+          + "  3. propose_remediation with a specific action (e.g., \"kubectl rollout restart deploy/api -n demo-app\").\n"
+          + "  4. request_human_approval, attaching your diagnosis and the proposed action.\n"
+          + "  5. If approved: execute_remediation, then prometheus_query to verify the symptom is gone, then report_resolved.\n"
+          + "  6. If rejected: report_unresolved with the operator's reason.\n\n"
+          + "Be terse. Conversation history is heartbeated to Temporal — keep tool inputs short.";
+
+  /** Pluggable I/O for the activity. Tests substitute their own. */
+  public interface TriageDeps {
+    List<McpToolInfo> mcpListTools(String baseUrl) throws Exception;
+
+    String mcpCallTool(String baseUrl, String name, Map<String, Object> args) throws Exception;
+
+    Types.ApprovalResponse requestHumanApproval(Types.AlertPayload alert, Types.ApprovalRequest req)
+        throws Exception;
+
+    ShellResult execShellCommand(String cmd) throws Exception;
+  }
+
+  public static final class McpToolInfo {
+    public String name;
+    public String description;
+    public Map<String, Object> inputSchema;
+  }
+
+  public static final class ShellResult {
+    public String stdout = "";
+    public String stderr = "";
+  }
+
+  /** Default deps wired to real MCP HTTP, real shell exec, real Temporal client for HITL. */
+  public static TriageDeps defaultDeps() {
+    return new TriageDeps() {
+      private final HttpClient http =
+          HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(5)).build();
+      private final ObjectMapper mapper = new ObjectMapper();
+
+      @Override
+      public List<McpToolInfo> mcpListTools(String baseUrl) throws Exception {
+        String body = mcpRpc(baseUrl, "tools/list", null);
+        Map<?, ?> root = mapper.readValue(body, Map.class);
+        Map<?, ?> result = (Map<?, ?>) root.get("result");
+        List<McpToolInfo> out = new ArrayList<>();
+        if (result == null) return out;
+        List<?> tools = (List<?>) result.get("tools");
+        if (tools == null) return out;
+        for (Object t : tools) {
+          Map<?, ?> m = (Map<?, ?>) t;
+          McpToolInfo info = new McpToolInfo();
+          info.name = (String) m.get("name");
+          Object descRaw = m.get("description");
+          info.description = descRaw != null ? (String) descRaw : "";
+          @SuppressWarnings("unchecked")
+          Map<String, Object> schema = (Map<String, Object>) m.get("inputSchema");
+          info.inputSchema = schema != null ? schema : Map.of("type", "object");
+          out.add(info);
+        }
+        return out;
+      }
+
+      @Override
+      public String mcpCallTool(String baseUrl, String name, Map<String, Object> args)
+          throws Exception {
+        String body = mcpRpc(baseUrl, "tools/call", Map.of("name", name, "arguments", args));
+        Map<?, ?> root = mapper.readValue(body, Map.class);
+        if (root.get("error") != null) {
+          return "MCP error: " + ((Map<?, ?>) root.get("error")).get("message");
+        }
+        Map<?, ?> result = (Map<?, ?>) root.get("result");
+        List<?> blocks = (List<?>) result.get("content");
+        StringBuilder sb = new StringBuilder();
+        for (Object b : blocks) {
+          Map<?, ?> m = (Map<?, ?>) b;
+          if (sb.length() > 0) sb.append("\n");
+          Object textRaw = m.get("text");
+          if (textRaw != null) sb.append(textRaw);
+        }
+        return sb.toString();
+      }
+
+      private String mcpRpc(String baseUrl, String method, Object params) throws Exception {
+        Map<String, Object> body = new java.util.LinkedHashMap<>();
+        body.put("jsonrpc", "2.0");
+        body.put("id", System.currentTimeMillis());
+        body.put("method", method);
+        if (params != null) body.put("params", params);
+        HttpRequest req =
+            HttpRequest.newBuilder(URI.create(baseUrl))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(mapper.writeValueAsString(body)))
+                .timeout(Duration.ofSeconds(30))
+                .build();
+        HttpResponse<String> resp = http.send(req, HttpResponse.BodyHandlers.ofString());
+        return resp.body();
+      }
+
+      @Override
+      public Types.ApprovalResponse requestHumanApproval(
+          Types.AlertPayload alert, Types.ApprovalRequest req) throws Exception {
+        return realRequestHumanApproval(alert, req);
+      }
+
+      @Override
+      public ShellResult execShellCommand(String cmd) throws Exception {
+        ProcessBuilder pb = new ProcessBuilder("sh", "-c", cmd);
+        pb.redirectErrorStream(false);
+        Process p = pb.start();
+        if (!p.waitFor(60, java.util.concurrent.TimeUnit.SECONDS)) {
+          p.destroyForcibly();
+          throw new IOException("exec timed out: " + cmd);
+        }
+        ShellResult r = new ShellResult();
+        r.stdout =
+            new String(p.getInputStream().readAllBytes(), java.nio.charset.StandardCharsets.UTF_8);
+        r.stderr =
+            new String(p.getErrorStream().readAllBytes(), java.nio.charset.StandardCharsets.UTF_8);
+        return r;
+      }
+    };
+  }
+
+  /** Build a populated registry plus a getter for the final result. Pure modulo deps. */
+  public static RegistryAndResult buildTriageRegistry(
+      Types.AlertPayload alert, AgenticSession session, TriageDeps deps) {
+    ToolRegistry registry = new ToolRegistry();
+    String promMcp = envOr("MCP_PROMETHEUS_URL", "http://localhost:7071/");
+    String k8sMcp = envOr("MCP_KUBERNETES_URL", "http://localhost:7072/");
+
+    // MCP-sourced tools.
+    registerMcpTools(registry, promMcp, deps);
+    registerMcpTools(registry, k8sMcp, deps);
+
+    // Per-language tools.
+    List<Types.ProposedRemediation> remediations = new ArrayList<>();
+    AtomicReference<String> approvedAction = new AtomicReference<>(null);
+    AtomicReference<Types.TriageResult> finalResult = new AtomicReference<>(null);
+
+    registry.register(
+        ToolDefinition.builder()
+            .name("propose_remediation")
+            .description("Record a remediation you would apply. Does NOT execute it.")
+            .inputSchema(
+                Map.of(
+                    "type", "object",
+                    "properties",
+                        Map.of(
+                            "action", Map.of("type", "string"),
+                            "justification", Map.of("type", "string")),
+                    "required", List.of("action", "justification")))
+            .build(),
+        (ToolHandler)
+            input -> {
+              Types.ProposedRemediation r =
+                  new Types.ProposedRemediation(
+                      String.valueOf(input.get("action")),
+                      String.valueOf(input.get("justification")));
+              remediations.add(r);
+              session.addResult(
+                  Map.of(
+                      "kind", "remediation", "action", r.action, "justification", r.justification));
+              return "recorded";
+            });
+
+    registry.register(
+        ToolDefinition.builder()
+            .name("request_human_approval")
+            .description("Block until operator decides. Returns JSON {decision, reason}.")
+            .inputSchema(
+                Map.of(
+                    "type", "object",
+                    "properties",
+                        Map.of(
+                            "message", Map.of("type", "string"),
+                            "diagnosis", Map.of("type", "string"),
+                            "proposedAction", Map.of("type", "string")),
+                    "required", List.of("message", "diagnosis", "proposedAction")))
+            .build(),
+        input -> {
+          Types.ApprovalRequest req = new Types.ApprovalRequest();
+          req.message = String.valueOf(input.get("message"));
+          req.diagnosis = String.valueOf(input.get("diagnosis"));
+          req.proposedAction = String.valueOf(input.get("proposedAction"));
+          Types.ApprovalResponse resp = deps.requestHumanApproval(alert, req);
+          if ("approved".equals(resp.decision)) {
+            approvedAction.set(req.proposedAction);
+          }
+          session.addResult(
+              Map.of("kind", "approval", "decision", resp.decision, "reason", resp.reason));
+          return "{\"decision\":\""
+              + resp.decision
+              + "\",\"reason\":\""
+              + jsonEscape(resp.reason)
+              + "\"}";
+        });
+
+    registry.register(
+        ToolDefinition.builder()
+            .name("execute_remediation")
+            .description(
+                "Execute the previously-approved action. Errors if no approval has been granted.")
+            .inputSchema(
+                Map.of(
+                    "type", "object",
+                    "properties", Map.of("action", Map.of("type", "string")),
+                    "required", List.of("action")))
+            .build(),
+        input -> {
+          String action = String.valueOf(input.get("action"));
+          if (approvedAction.get() == null) {
+            return "ERROR: no approval has been granted. Call request_human_approval first.";
+          }
+          if (!action.equals(approvedAction.get())) {
+            return "ERROR: requested action does not match approved action. Approved: "
+                + approvedAction.get();
+          }
+          ShellResult r = deps.execShellCommand(action);
+          session.addResult(
+              Map.of(
+                  "kind",
+                  "executed",
+                  "action",
+                  action,
+                  "stdout",
+                  clip(r.stdout, 2000),
+                  "stderr",
+                  clip(r.stderr, 2000)));
+          String out = !r.stdout.isEmpty() ? r.stdout : (!r.stderr.isEmpty() ? r.stderr : "ok");
+          return clip(out, 4000);
+        });
+
+    registry.register(
+        ToolDefinition.builder()
+            .name("report_resolved")
+            .description("Ends the loop with status=resolved.")
+            .inputSchema(
+                Map.of(
+                    "type", "object",
+                    "properties", Map.of("summary", Map.of("type", "string")),
+                    "required", List.of("summary")))
+            .build(),
+        input -> {
+          Types.TriageResult r = new Types.TriageResult();
+          r.status = "resolved";
+          r.summary = String.valueOf(input.get("summary"));
+          r.remediations = new ArrayList<>(remediations);
+          finalResult.set(r);
+          session.addResult(Map.of("kind", "final", "status", r.status, "summary", r.summary));
+          return "ok";
+        });
+
+    registry.register(
+        ToolDefinition.builder()
+            .name("report_unresolved")
+            .description("Ends the loop with status=unresolved.")
+            .inputSchema(
+                Map.of(
+                    "type", "object",
+                    "properties", Map.of("summary", Map.of("type", "string")),
+                    "required", List.of("summary")))
+            .build(),
+        input -> {
+          Types.TriageResult r = new Types.TriageResult();
+          r.status = "unresolved";
+          r.summary = String.valueOf(input.get("summary"));
+          r.remediations = new ArrayList<>(remediations);
+          finalResult.set(r);
+          session.addResult(Map.of("kind", "final", "status", r.status, "summary", r.summary));
+          return "ok";
+        });
+
+    return new RegistryAndResult(registry, finalResult::get);
+  }
+
+  private static void registerMcpTools(ToolRegistry registry, String baseUrl, TriageDeps deps) {
+    try {
+      for (McpToolInfo t : deps.mcpListTools(baseUrl)) {
+        final String name = t.name;
+        Map<String, Object> schema =
+            t.inputSchema != null ? t.inputSchema : Map.of("type", "object");
+        registry.register(
+            ToolDefinition.builder()
+                .name(name)
+                .description(t.description == null ? "" : t.description)
+                .inputSchema(schema)
+                .build(),
+            (ToolHandler) input -> deps.mcpCallTool(baseUrl, name, input));
+      }
+    } catch (Exception ignored) {
+      // MCP server unreachable in testing or at boot — proceed without these tools.
+    }
+  }
+
+  public static String buildPrompt(Types.AlertPayload alert) {
+    return "Alert fired: "
+        + getOr(alert.labels, "alertname", "unknown")
+        + " on "
+        + getOr(alert.labels, "service", "unknown")
+        + ".\nSummary: "
+        + getOr(alert.annotations, "summary", "(none)")
+        + "\nDescription: "
+        + getOr(alert.annotations, "description", "(none)")
+        + "\nRunbook hint: "
+        + getOr(alert.labels, "runbook", "(none)")
+        + "\n\nInvestigate, propose, get approval, and either fix or report unresolved.";
+  }
+
+  public static final class RegistryAndResult {
+    public final ToolRegistry registry;
+    public final java.util.function.Supplier<Types.TriageResult> getResult;
+
+    public RegistryAndResult(ToolRegistry r, java.util.function.Supplier<Types.TriageResult> g) {
+      this.registry = r;
+      this.getResult = g;
+    }
+  }
+
+  @Override
+  public Types.TriageResult triageIncident(Types.AlertPayload alert) {
+    TriageDeps deps = defaultDeps();
+    AtomicReference<Types.TriageResult> out = new AtomicReference<>();
+    try {
+      AgenticSession.runWithSession(
+          session -> {
+            RegistryAndResult rar = buildTriageRegistry(alert, session, deps);
+            AnthropicConfig cfg =
+                AnthropicConfig.builder().apiKey(System.getenv("ANTHROPIC_API_KEY")).build();
+            AnthropicProvider provider = new AnthropicProvider(cfg, rar.registry, SYSTEM_PROMPT);
+            session.runToolLoop(provider, rar.registry, buildPrompt(alert));
+            Types.TriageResult final_ = rar.getResult.get();
+            if (final_ == null) {
+              throw new RuntimeException(
+                  "Agent ended the loop without calling report_resolved or report_unresolved");
+            }
+            out.set(final_);
+          });
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+    return out.get();
+  }
+
+  static Types.ApprovalResponse realRequestHumanApproval(
+      Types.AlertPayload alert, Types.ApprovalRequest req) {
+    String address = System.getenv("TEMPORAL_ADDRESS");
+    String namespace = System.getenv("TEMPORAL_NAMESPACE");
+    String apiKey = System.getenv("TEMPORAL_API_KEY");
+    String taskQueue = envOr("TEMPORAL_TASK_QUEUE", "triage-java");
+    if (address == null || namespace == null || apiKey == null) {
+      throw new IllegalStateException(
+          "Missing TEMPORAL_ADDRESS / TEMPORAL_NAMESPACE / TEMPORAL_API_KEY");
+    }
+    WorkflowServiceStubs service =
+        WorkflowServiceStubs.newServiceStubs(
+            WorkflowServiceStubsOptions.newBuilder()
+                .setTarget(address)
+                .addApiKey(() -> apiKey)
+                .build());
+    WorkflowClient client =
+        WorkflowClient.newInstance(
+            service,
+            io.temporal.client.WorkflowClientOptions.newBuilder().setNamespace(namespace).build());
+
+    String key =
+        (getOr(alert.labels, "alertname", "unknown")
+                + "-"
+                + getOr(alert.labels, "service", "unknown"))
+            .toLowerCase(java.util.Locale.ROOT);
+    String wfId = "approval-" + key;
+
+    ApprovalWorkflow stub =
+        client.newWorkflowStub(
+            ApprovalWorkflow.class,
+            WorkflowOptions.newBuilder().setWorkflowId(wfId).setTaskQueue(taskQueue).build());
+
+    // signal-with-start: initial start carries the request signal.
+    var unused = WorkflowClient.execute(stub::run, key);
+    stub.approvalRequest(req);
+    return stub.run(key); // already running; this returns the in-flight result
+  }
+
+  static String envOr(String n, String d) {
+    String v = System.getenv(n);
+    return v == null || v.isEmpty() ? d : v;
+  }
+
+  static String getOr(Map<String, String> m, String k, String d) {
+    if (m == null) return d;
+    String v = m.get(k);
+    return v == null || v.isEmpty() ? d : v;
+  }
+
+  static String clip(String s, int n) {
+    return s.length() <= n ? s : s.substring(0, n);
+  }
+
+  static String jsonEscape(String s) {
+    return s == null ? "" : s.replace("\\", "\\\\").replace("\"", "\\\"").replace("\n", "\\n");
+  }
+}

--- a/core/src/main/java/io/temporal/samples/toolregistryincidenttriage/TriageActivityImpl.java
+++ b/core/src/main/java/io/temporal/samples/toolregistryincidenttriage/TriageActivityImpl.java
@@ -1,8 +1,10 @@
 package io.temporal.samples.toolregistryincidenttriage;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.temporal.api.enums.v1.WorkflowIdConflictPolicy;
 import io.temporal.client.WorkflowClient;
 import io.temporal.client.WorkflowOptions;
+import io.temporal.client.WorkflowStub;
 import io.temporal.serviceclient.WorkflowServiceStubs;
 import io.temporal.serviceclient.WorkflowServiceStubsOptions;
 import io.temporal.toolregistry.AgenticSession;
@@ -421,11 +423,21 @@ public class TriageActivityImpl implements TriageActivity {
     ApprovalWorkflow stub =
         client.newWorkflowStub(
             ApprovalWorkflow.class,
-            WorkflowOptions.newBuilder().setWorkflowId(wfId).setTaskQueue(taskQueue).build());
+            WorkflowOptions.newBuilder()
+                .setWorkflowId(wfId)
+                .setTaskQueue(taskQueue)
+                // If the activity retries while the approval workflow is still running,
+                // attach to the existing one rather than starting a new approval. The
+                // operator should not get a second prompt for the same incident.
+                .setWorkflowIdConflictPolicy(
+                    WorkflowIdConflictPolicy.WORKFLOW_ID_CONFLICT_POLICY_USE_EXISTING)
+                .build());
 
-    // signal-with-start: initial start carries the request signal.
-    var unused = WorkflowClient.execute(stub::run, key);
-    stub.approvalRequest(req);
+    // Atomic signal-with-start: send the request signal in the same call that starts
+    // the workflow. Avoids the race where a separate signal could arrive before the
+    // workflow registers its handler.
+    WorkflowStub.fromTyped(stub)
+        .signalWithStart("approval-request", new Object[] {req}, new Object[] {key});
     return stub.run(key); // already running; this returns the in-flight result
   }
 

--- a/core/src/main/java/io/temporal/samples/toolregistryincidenttriage/Types.java
+++ b/core/src/main/java/io/temporal/samples/toolregistryincidenttriage/Types.java
@@ -1,0 +1,55 @@
+package io.temporal.samples.toolregistryincidenttriage;
+
+import java.util.List;
+import java.util.Map;
+
+/** Shared types for the Java triage worker. POJOs with public fields for Jackson. */
+public final class Types {
+
+  public static final class AlertPayload {
+    public String status;
+    public Map<String, String> labels;
+    public Map<String, String> annotations;
+    public String startsAt;
+    public String endsAt;
+    public String fingerprint;
+  }
+
+  public static final class ProposedRemediation {
+    public String action;
+    public String justification;
+
+    public ProposedRemediation() {}
+
+    public ProposedRemediation(String action, String justification) {
+      this.action = action;
+      this.justification = justification;
+    }
+  }
+
+  public static final class TriageResult {
+    public String status; // "resolved" | "unresolved"
+    public String summary;
+    public List<ProposedRemediation> remediations;
+  }
+
+  public static final class ApprovalRequest {
+    public String message;
+    public String diagnosis;
+    public String proposedAction;
+  }
+
+  public static final class ApprovalResponse {
+    public String decision; // "approved" | "rejected"
+    public String reason;
+
+    public ApprovalResponse() {}
+
+    public ApprovalResponse(String decision, String reason) {
+      this.decision = decision;
+      this.reason = reason;
+    }
+  }
+
+  private Types() {}
+}

--- a/core/src/main/java/io/temporal/samples/toolregistryincidenttriage/Worker.java
+++ b/core/src/main/java/io/temporal/samples/toolregistryincidenttriage/Worker.java
@@ -1,0 +1,53 @@
+package io.temporal.samples.toolregistryincidenttriage;
+
+import io.temporal.client.WorkflowClient;
+import io.temporal.client.WorkflowClientOptions;
+import io.temporal.serviceclient.WorkflowServiceStubs;
+import io.temporal.serviceclient.WorkflowServiceStubsOptions;
+import io.temporal.worker.WorkerFactory;
+
+public class Worker {
+  public static void main(String[] args) {
+    String address = mustEnv("TEMPORAL_ADDRESS");
+    String namespace = mustEnv("TEMPORAL_NAMESPACE");
+    String apiKey = mustEnv("TEMPORAL_API_KEY");
+    String taskQueue = envOr("TEMPORAL_TASK_QUEUE", "triage-java");
+
+    System.out.println(
+        "connecting to " + address + " (ns=" + namespace + ") on task queue " + taskQueue);
+
+    WorkflowServiceStubs service =
+        WorkflowServiceStubs.newServiceStubs(
+            WorkflowServiceStubsOptions.newBuilder()
+                .setTarget(address)
+                .addApiKey(() -> apiKey)
+                .build());
+
+    WorkflowClient client =
+        WorkflowClient.newInstance(
+            service, WorkflowClientOptions.newBuilder().setNamespace(namespace).build());
+
+    WorkerFactory factory = WorkerFactory.newInstance(client);
+    io.temporal.worker.Worker worker = factory.newWorker(taskQueue);
+    worker.registerWorkflowImplementationTypes(
+        IncidentTriageWorkflowImpl.class, ApprovalWorkflowImpl.class);
+    worker.registerActivitiesImplementations(new TriageActivityImpl());
+
+    System.out.println("worker ready — polling " + taskQueue);
+    factory.start();
+  }
+
+  private static String mustEnv(String name) {
+    String v = System.getenv(name);
+    if (v == null || v.isEmpty()) {
+      System.err.println("missing env var: " + name);
+      System.exit(1);
+    }
+    return v;
+  }
+
+  private static String envOr(String name, String def) {
+    String v = System.getenv(name);
+    return v == null || v.isEmpty() ? def : v;
+  }
+}

--- a/core/src/test/java/io/temporal/samples/toolregistryincidenttriage/TriageActivityTest.java
+++ b/core/src/test/java/io/temporal/samples/toolregistryincidenttriage/TriageActivityTest.java
@@ -1,0 +1,360 @@
+package io.temporal.samples.toolregistryincidenttriage;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import io.temporal.samples.toolregistryincidenttriage.TriageActivityImpl.McpToolInfo;
+import io.temporal.samples.toolregistryincidenttriage.TriageActivityImpl.RegistryAndResult;
+import io.temporal.samples.toolregistryincidenttriage.TriageActivityImpl.ShellResult;
+import io.temporal.samples.toolregistryincidenttriage.TriageActivityImpl.TriageDeps;
+import io.temporal.toolregistry.AgenticSession;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for buildTriageRegistry. Drives the registry directly via dispatch — bypasses
+ * runWithSession and the LLM provider. Mirrors the TS / Python / Go suites.
+ */
+class TriageActivityTest {
+
+  private Types.AlertPayload makeAlert() {
+    Types.AlertPayload a = new Types.AlertPayload();
+    a.status = "firing";
+    a.labels =
+        Map.of("alertname", "HighLatencyP99", "service", "api", "runbook", "rollback-or-scale");
+    a.annotations = Map.of("summary", "P99 > 1s", "description", "P99 above threshold for 1m.");
+    a.startsAt = Instant.now().toString();
+    return a;
+  }
+
+  private TriageDeps makeDeps() {
+    return new TriageDeps() {
+      @Override
+      public List<McpToolInfo> mcpListTools(String baseUrl) {
+        McpToolInfo t = new McpToolInfo();
+        if (baseUrl.contains("7071")) {
+          t.name = "prometheus_query";
+          t.description = "instant PromQL query";
+          t.inputSchema =
+              Map.of(
+                  "type",
+                  "object",
+                  "properties",
+                  Map.of("query", Map.of("type", "string")),
+                  "required",
+                  List.of("query"));
+        } else {
+          t.name = "kubectl_describe";
+          t.description = "describe a k8s resource";
+          t.inputSchema =
+              Map.of(
+                  "type",
+                  "object",
+                  "properties",
+                  Map.of(
+                      "resource", Map.of("type", "string"),
+                      "name", Map.of("type", "string"),
+                      "namespace", Map.of("type", "string")),
+                  "required",
+                  List.of("resource", "name"));
+        }
+        return List.of(t);
+      }
+
+      @Override
+      public String mcpCallTool(String baseUrl, String name, Map<String, Object> args) {
+        return "(mocked " + name + ")";
+      }
+
+      @Override
+      public Types.ApprovalResponse requestHumanApproval(
+          Types.AlertPayload a, Types.ApprovalRequest r) {
+        return new Types.ApprovalResponse("approved", "default-mock");
+      }
+
+      @Override
+      public ShellResult execShellCommand(String cmd) {
+        ShellResult r = new ShellResult();
+        r.stdout = "(mocked exec: " + cmd + ")";
+        return r;
+      }
+    };
+  }
+
+  private record Call(String name, Map<String, Object> input) {}
+
+  private record DriveResult(Types.TriageResult result, List<Map<String, Object>> sessionResults) {}
+
+  private DriveResult drive(TriageDeps deps, Call... calls) throws Exception {
+    AgenticSession session = new AgenticSession();
+    RegistryAndResult rar = TriageActivityImpl.buildTriageRegistry(makeAlert(), session, deps);
+    for (Call c : calls) {
+      rar.registry.dispatch(c.name(), c.input());
+    }
+    return new DriveResult(rar.getResult.get(), session.getResults());
+  }
+
+  @Test
+  void happyPathResolved() throws Exception {
+    AtomicInteger approvalCalls = new AtomicInteger(0);
+    TriageDeps deps =
+        override(
+            makeDeps(),
+            b ->
+                b.requestHumanApproval =
+                    (a, r) -> {
+                      approvalCalls.incrementAndGet();
+                      return new Types.ApprovalResponse("approved", "go ahead");
+                    });
+    String action = "kubectl rollout restart deploy/api -n demo-app";
+
+    DriveResult dr =
+        drive(
+            deps,
+            new Call("prometheus_query", Map.of("query", "up{service='api'}")),
+            new Call(
+                "kubectl_describe",
+                Map.of("resource", "pod", "name", "api-xyz", "namespace", "demo-app")),
+            new Call(
+                "propose_remediation",
+                Map.of("action", action, "justification", "leak; restart reclaims memory")),
+            new Call(
+                "request_human_approval",
+                Map.of(
+                    "message",
+                    "Restart api?",
+                    "diagnosis",
+                    "memory leak",
+                    "proposedAction",
+                    action)),
+            new Call("execute_remediation", Map.of("action", action)),
+            new Call("report_resolved", Map.of("summary", "restarted; latency normal")));
+
+    assertNotNull(dr.result());
+    assertEquals("resolved", dr.result().status);
+    assertTrue(dr.result().summary.contains("restart"));
+    assertEquals(1, dr.result().remediations.size());
+    assertEquals(action, dr.result().remediations.get(0).action);
+    assertEquals(1, approvalCalls.get());
+
+    List<String> kinds = dr.sessionResults().stream().map(r -> (String) r.get("kind")).toList();
+    assertEquals(List.of("remediation", "approval", "executed", "final"), kinds);
+  }
+
+  @Test
+  void rejectedApprovalUnresolved() throws Exception {
+    TriageDeps deps =
+        override(
+            makeDeps(),
+            b ->
+                b.requestHumanApproval =
+                    (a, r) ->
+                        new Types.ApprovalResponse("rejected", "off-hours; defer until tomorrow"));
+
+    DriveResult dr =
+        drive(
+            deps,
+            new Call(
+                "propose_remediation",
+                Map.of("action", "kubectl scale ...", "justification", "transient")),
+            new Call(
+                "request_human_approval",
+                Map.of(
+                    "message",
+                    "Scale?",
+                    "diagnosis",
+                    "transient",
+                    "proposedAction",
+                    "kubectl scale ...")),
+            new Call("report_unresolved", Map.of("summary", "operator deferred")));
+
+    assertEquals("unresolved", dr.result().status);
+    assertTrue(dr.result().summary.contains("deferred"));
+    Map<String, Object> approval =
+        dr.sessionResults().stream()
+            .filter(r -> "approval".equals(r.get("kind")))
+            .findFirst()
+            .orElse(null);
+    assertNotNull(approval);
+    assertEquals("rejected", approval.get("decision"));
+    assertTrue(((String) approval.get("reason")).contains("off-hours"));
+  }
+
+  @Test
+  void executeRefusesWithoutApproval() throws Exception {
+    AtomicReference<String> executedCmd = new AtomicReference<>(null);
+    TriageDeps deps =
+        override(
+            makeDeps(),
+            b ->
+                b.execShellCommand =
+                    cmd -> {
+                      executedCmd.set(cmd);
+                      ShellResult r = new ShellResult();
+                      r.stdout = "ran";
+                      return r;
+                    });
+
+    DriveResult dr =
+        drive(
+            deps,
+            new Call("execute_remediation", Map.of("action", "rm -rf /")),
+            new Call("report_unresolved", Map.of("summary", "tried to skip approval")));
+
+    assertEquals("unresolved", dr.result().status);
+    assertNull(executedCmd.get(), "ExecShellCommand should not have been called");
+  }
+
+  @Test
+  void executeRefusesWhenActionDoesNotMatch() throws Exception {
+    AtomicReference<String> executedCmd = new AtomicReference<>(null);
+    TriageDeps deps =
+        override(
+            makeDeps(),
+            b -> {
+              b.requestHumanApproval = (a, r) -> new Types.ApprovalResponse("approved", "ok");
+              b.execShellCommand =
+                  cmd -> {
+                    executedCmd.set(cmd);
+                    ShellResult r = new ShellResult();
+                    r.stdout = "ran";
+                    return r;
+                  };
+            });
+
+    DriveResult dr =
+        drive(
+            deps,
+            new Call(
+                "propose_remediation",
+                Map.of("action", "kubectl restart api", "justification", "x")),
+            new Call(
+                "request_human_approval",
+                Map.of(
+                    "message",
+                    "Restart?",
+                    "diagnosis",
+                    "x",
+                    "proposedAction",
+                    "kubectl restart api")),
+            new Call(
+                "execute_remediation", Map.of("action", "kubectl scale deploy/api --replicas=10")),
+            new Call("report_unresolved", Map.of("summary", "guard tripped")));
+
+    assertEquals("unresolved", dr.result().status);
+    assertNull(
+        executedCmd.get(),
+        "ExecShellCommand should not have been called when action did not match");
+  }
+
+  @Test
+  void mcpToolsRegistered() throws Exception {
+    AgenticSession session = new AgenticSession();
+    RegistryAndResult rar =
+        TriageActivityImpl.buildTriageRegistry(makeAlert(), session, makeDeps());
+    List<String> names = new ArrayList<>();
+    rar.registry.toAnthropic().forEach(t -> names.add((String) t.get("name")));
+    for (String want :
+        Arrays.asList(
+            "prometheus_query",
+            "kubectl_describe",
+            "propose_remediation",
+            "request_human_approval",
+            "execute_remediation",
+            "report_resolved",
+            "report_unresolved")) {
+      assertTrue(names.contains(want), "missing tool: " + want);
+    }
+  }
+
+  @Test
+  void mcpDispatchForwardsToSidecar() throws Exception {
+    record Recorded(String url, String name, Map<String, Object> args) {}
+    List<Recorded> calls = new ArrayList<>();
+    TriageDeps base = makeDeps();
+    TriageDeps deps =
+        new TriageDeps() {
+          @Override
+          public List<McpToolInfo> mcpListTools(String url) throws Exception {
+            return base.mcpListTools(url);
+          }
+
+          @Override
+          public String mcpCallTool(String url, String name, Map<String, Object> args) {
+            calls.add(new Recorded(url, name, args));
+            return "result for " + name;
+          }
+
+          @Override
+          public Types.ApprovalResponse requestHumanApproval(
+              Types.AlertPayload a, Types.ApprovalRequest r) throws Exception {
+            return base.requestHumanApproval(a, r);
+          }
+
+          @Override
+          public ShellResult execShellCommand(String cmd) throws Exception {
+            return base.execShellCommand(cmd);
+          }
+        };
+
+    drive(
+        deps,
+        new Call("prometheus_query", Map.of("query", "up{}")),
+        new Call("report_unresolved", Map.of("summary", "test")));
+
+    assertEquals(1, calls.size());
+    assertEquals("prometheus_query", calls.get(0).name());
+    assertTrue(calls.get(0).url().contains("7071"));
+    assertEquals("up{}", calls.get(0).args().get("query"));
+  }
+
+  /** Mutable bag for overriding dep functions in test cases without writing 4-arg constructors. */
+  static class DepsBag {
+    TriageDeps base;
+    java.util.function.BiFunction<Types.AlertPayload, Types.ApprovalRequest, Types.ApprovalResponse>
+        requestHumanApproval;
+    FunctionThrowing<String, ShellResult> execShellCommand;
+  }
+
+  @FunctionalInterface
+  interface FunctionThrowing<T, R> {
+    R apply(T t) throws Exception;
+  }
+
+  static TriageDeps override(TriageDeps base, java.util.function.Consumer<DepsBag> mutator) {
+    DepsBag bag = new DepsBag();
+    bag.base = base;
+    mutator.accept(bag);
+    return new TriageDeps() {
+      @Override
+      public List<McpToolInfo> mcpListTools(String url) throws Exception {
+        return base.mcpListTools(url);
+      }
+
+      @Override
+      public String mcpCallTool(String url, String n, Map<String, Object> a) throws Exception {
+        return base.mcpCallTool(url, n, a);
+      }
+
+      @Override
+      public Types.ApprovalResponse requestHumanApproval(
+          Types.AlertPayload a, Types.ApprovalRequest r) throws Exception {
+        return bag.requestHumanApproval != null
+            ? bag.requestHumanApproval.apply(a, r)
+            : base.requestHumanApproval(a, r);
+      }
+
+      @Override
+      public ShellResult execShellCommand(String cmd) throws Exception {
+        return bag.execShellCommand != null
+            ? bag.execShellCommand.apply(cmd)
+            : base.execShellCommand(cmd);
+      }
+    };
+  }
+}


### PR DESCRIPTION
Adds a new sample under `core/src/main/java/io/temporal/samples/toolregistryincidenttriage/` demonstrating `io.temporal.toolregistry` end-to-end.

The example includes:

- Long-running activity wrapped in `AgenticSession.runWithSession` with heartbeat checkpointing.
- MCP HTTP integration via the sidecar pattern (Prometheus + Kubernetes MCP servers).
- Human-in-the-loop tool calls via a companion workflow (deterministic ID, two signals, one query).
- A testable activity refactor: `buildTriageRegistry(alert, session, deps)` returning `RegistryAndResult` plus a `TriageDeps` interface of I/O callables, so unit tests substitute fakes and drive the registry via `MockProvider`.

JUnit tests in `core/src/test/java/.../TriageActivityTest.java` use `MockProvider` and require no API key or running Temporal server.

Adds `temporal-tool-registry` and `anthropic-java` to `core/build.gradle`. The contrib module is in development. Install to mavenLocal first via `JAVA_HOME=$JDK21 ./gradlew :temporal-tool-registry:publishToMavenLocal` from the sdk-java repo.

Cross-references the SDK PR (temporalio/sdk-java#2839) which adds the `temporal-tool-registry` module itself.